### PR TITLE
release: merge develop → main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.amazonq
 localstorage
 manifest.json
 node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ Todos los cambios notables de este proyecto se documentan aquí.
 Formato basado en [Keep a Changelog](https://keepachangelog.com/es/1.0.0/).
 Versionado según [Semantic Versioning](https://semver.org/lang/es/).
 
+## [Unreleased]
+
+## [1.4.0] - 2026-05-27
+
+### Added
+
+- Función `getCardBlock(cardId, block)` para resolver el bloque de una carta dado su ID y el campo `block` del set
+- Atributo `data-block` en todas las imágenes de carta (sets base y variantes)
+- Inputs de cantidad por bloque en `drawAlternatives`: un input por cada bloque distinto que tenga la carta
+- Sets sin `block` definido (Promos) reciben `data-block` dinámicamente al procesar sus variantes
+- Filtro por bloque en la barra de filtros (después de rareza)
+- Al filtrar por bloque, se ocultan también los inputs de cantidad que no correspondan al bloque seleccionado
+
+## [1.3.0] - 2026-05-25
+
+### Added
+
+- Sets de 2026: Evolution Cup 2026 Vol.1 y Vol.2, World Championship 2025, Regionals 2026/27 Season 1, Ultimate Cup 2026 Vol.1, OTP21/WP21, Judge Pack 9, ST-23, ST-24, LM Memory Boost, BT-25, EX-12, LM-09 y sus variantes
+- Nuevos colores CSS: `green-white`, `purple-red-green`
+- Nueva rareza `ur` (Ultimate Rare) en datos, filtro y estilos
+
+## [1.2.0] - 2026-05-25
+
+### Added
+
+- Campo `block` asignado a todos los sets en todos los archivos `data_*.js`
+- Soporte de `block` como mapa bloque → cartas para sets con cartas de distintos bloques
+
 ## [1.1.1] - 2025-01-01
 
 ### Estado base
@@ -18,4 +46,8 @@ Versionado según [Semantic Versioning](https://semver.org/lang/es/).
 - Soporte de impresión con CSS dedicado
 - Migraciones de datos en localStorage (`updates.js`)
 
+[Unreleased]: https://github.com/Vegekku/dtcg-web/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/Vegekku/dtcg-web/compare/v1.3.0...v1.4.0
+[1.3.0]: https://github.com/Vegekku/dtcg-web/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/Vegekku/dtcg-web/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/Vegekku/dtcg-web/releases/tag/v1.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+Todos los cambios notables de este proyecto se documentan aquí.
+Formato basado en [Keep a Changelog](https://keepachangelog.com/es/1.0.0/).
+Versionado según [Semantic Versioning](https://semver.org/lang/es/).
+
+## [1.1.1] - 2025-01-01
+
+### Estado base
+
+- Navegación por categorías: Boosters (BT), Starters (ST), Extras (EX) y otros productos
+- Edición de colección con modal: estado, precio y URL de Cardmarket por carta
+- Filtros combinados por estado, color primario, set y rareza
+- Vista en tabla o grid
+- Soporte para arts alternativos, reprints y gold foil
+- Exportación de colección y datos de Cardmarket como JSON
+- Datos persistidos en localStorage
+- Soporte de impresión con CSS dedicado
+- Migraciones de datos en localStorage (`updates.js`)
+
+[1.1.1]: https://github.com/Vegekku/dtcg-web/releases/tag/v1.1.1

--- a/DATA_MODEL.md
+++ b/DATA_MODEL.md
@@ -434,6 +434,8 @@ Estructura del objeto `collection` almacenado en localStorage:
 | `[setId][cardId].reprint` | `object` | Opcional. Cantidad de copias por bloque de reprint: `{ "5": 2 }` |
 | `products.packs[slug]` | `object` | Estado y precio de cada sobre/producto |
 
+> **Pendiente (#37):** `amount` pasará a ser un mapa por bloque `{ "0": 2, "1": 3 }` y se eliminará el campo `reprint`. La suma total se calculará en runtime. Ver issue [#37](https://github.com/Vegekku/dtcg-web/issues/37).
+
 ---
 
 ## localStorage: cardmarket

--- a/DATA_MODEL.md
+++ b/DATA_MODEL.md
@@ -226,6 +226,7 @@ Rarezas soportadas:
 | `r` | Rare |
 | `sr` | Super Rare |
 | `sec` | Secret Rare |
+| `ur` | Ultimate Rare |
 | `p` | Promo |
 | `aa` | Alternative Art (valor por defecto si no se especifica) |
 | `sp` | Special |

--- a/DATA_MODEL.md
+++ b/DATA_MODEL.md
@@ -1,0 +1,480 @@
+# Modelo de datos — DTCG Web Collection
+
+Documentación del modelo de datos utilizado en los archivos `js/data/data_*.js` y en localStorage.
+
+## Índice
+
+- [Sets (datos estáticos)](#sets-datos-estáticos)
+  - [Sets con ID (sets base)](#sets-con-id-sets-base)
+  - [Sets sin ID (variantes)](#sets-sin-id-variantes)
+  - [Campos comunes](#campos-comunes)
+  - [Campos exclusivos de sets base](#campos-exclusivos-de-sets-base)
+  - [Campos exclusivos de variantes](#campos-exclusivos-de-variantes)
+- [Sistema de URLs e imágenes](#sistema-de-urls-e-imágenes)
+  - [Placeholders en URLs](#placeholders-en-urls)
+  - [Bases de URL](#bases-de-url)
+  - [Override](#override)
+  - [Parallel](#parallel)
+- [Color](#color)
+- [Rareza](#rareza)
+- [Bloques y reprints](#bloques-y-reprints)
+- [Slug y relación set-producto](#slug-y-relación-set-producto)
+- [Productos](#productos)
+- [Estados de carta](#estados-de-carta)
+- [localStorage: collection](#localstorage-collection)
+- [localStorage: cardmarket](#localstorage-cardmarket)
+- [Decisiones de diseño](#decisiones-de-diseño)
+
+---
+
+## Sets (datos estáticos)
+
+Todos los sets se definen como objetos en los archivos `js/data/data_*.js` y se concatenan en un único array `sets` en `js/sets.js`.
+
+Existen dos tipos de sets según el valor de `id`:
+
+### Sets con ID (sets base)
+
+Representan un conjunto de cartas con identidad propia (ej. `"BT1"`, `"ST7"`, `"EX8"`). Generan una tabla HTML con todas sus cartas numeradas del 1 al `total`.
+
+```js
+{
+    "id": "BT21",           // Identificador del set
+    "block": 5,             // Bloque temporal
+    "slug": "bt21",         // Identificador del producto/release
+    "name": "Booster World Convergence [BT21]",
+    "release": "April 2025",
+    "total": 102,           // Número total de cartas
+    "url": "bandaitcgplusURL/BT21/e_setID-cardID_d.png",
+    "add_zero": 3,          // Padding de ceros en el ID (3 → "001", 2 → "01")
+    "color": { ... },
+    "rarity": { ... },
+    "override": { ... },    // Opcional
+    "pack": "https://...",  // Opcional: imagen del sobre
+    "playmat": "https://...", // Opcional
+    "info_url": "https://..."
+}
+```
+
+### Sets sin ID (variantes)
+
+Representan variantes de cartas existentes: arts alternativos, reprints, limited cards, special cards, box toppers, promos de eventos, etc. No generan tabla propia; sus cartas se inyectan en las filas de los sets base correspondientes.
+
+```js
+{
+    "id": null,
+    "slug": "bt21_alts",
+    "name": "Booster World Convergence [BT21] - Alternatives",
+    "release": "April 2025",
+    "url": "bandaitcgplusURL/BT21/e_setID-cardIDp_dparallel.png",
+    "cards": {              // Mapa de cardNumber → parallel
+        "BT21-008": "",
+        "BT21-029": "",
+    },
+    "rarity": { ... },      // Opcional
+    "rarities": { ... },    // Opcional (cuando inyecta en múltiples sets)
+    "reprint": true,         // Opcional
+    "block": 5,              // Opcional (solo con reprint)
+    "info_url": "https://..."
+}
+```
+
+### Campos comunes
+
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| `id` | `string \| null` | ID del set (`"BT1"`) o `null` para variantes |
+| `slug` | `string` | Identificador del producto/release al que pertenece |
+| `name` | `string` | Nombre completo del set o variante |
+| `release` | `string \| null` | Fecha de lanzamiento |
+| `url` | `string \| null` | Plantilla de URL para las imágenes. `null` indica que no se debe generar URL automáticamente: bien porque es un set base sin imágenes propias (ej. `P`, `BT1`), o bien porque las URLs vienen indicadas directamente como valores dentro de `cards` |
+| `info_url` | `string \| null` | URL con información oficial del set |
+| `rarity` | `string \| object` | Rareza de las cartas (ver [Rareza](#rareza)) |
+| `pack` | `string \| string[]` | Opcional. URL(s) de imagen del sobre/producto |
+| `playmat` | `string` | Opcional. URL de imagen del playmat |
+
+### Campos exclusivos de sets base
+
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| `total` | `number` | Número total de cartas en el set |
+| `block` | `number` | Bloque temporal al que pertenece el set (ver [Bloques](#bloques-y-reprints)) |
+| `add_zero` | `number` | Dígitos de padding para el ID de carta (2 → `"01"`, 3 → `"001"`) |
+| `color` | `string \| object` | Color(es) de las cartas (ver [Color](#color)) |
+| `override` | `object` | Opcional. URLs alternativas para cartas específicas (ver [Override](#override)) |
+
+### Campos exclusivos de variantes
+
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| `cards` | `object` | Mapa `{ "SET-ID": parallel }` de cartas incluidas (ver [Parallel](#parallel)) |
+| `rarities` | `object` | Opcional. Rarezas por set cuando la variante inyecta en múltiples sets |
+| `reprint` | `boolean` | Opcional. Indica que las cartas son reimpresas de otro bloque |
+| `block` | `number` | Opcional. Bloque temporal al que pertenece el reprint (ver [Bloques](#bloques-y-reprints)) |
+
+---
+
+## Sistema de URLs e imágenes
+
+### Placeholders en URLs
+
+Las URLs de imágenes usan placeholders que se reemplazan dinámicamente:
+
+| Placeholder | Se reemplaza por | Ejemplo |
+|-------------|-----------------|---------|
+| `setID` | ID del set | `BT21` |
+| `cardID` | ID numérico de la carta (con padding) | `008` |
+| `parallel` | Sufijo de variante paralela | `P1`, `_d`, `SP` |
+
+Ejemplo: `"bandaitcgplusURL/BT21/e_setID-cardIDp_dparallel.png"` → `"https://files.bandai-tcg-plus.com/card_image/DG-EN/BT21/e_BT21-008p_d.png"`
+
+### Bases de URL
+
+Las URLs usan alias que se resuelven a URLs completas:
+
+| Alias | URL real |
+|-------|---------|
+| `bandaitcgplusURL` | `https://files.bandai-tcg-plus.com/card_image/DG-EN` |
+| `digimoncardURL` | `https://world.digimoncard.com/images/cardlist/card` |
+| `digimoncardjpURL` | `https://digimoncard.com/images/cardlist/card` |
+| `digimonCardDev` | `https://assets.cardlist.dev/images/communitycards` |
+| `digimonFandom` | `https://static.wikia.nocookie.net/digimoncardgame/images` |
+| `noCardURL` | `https://assets.cardlist.dev/other/2020_card_backstage_design.jpg` (placeholder) |
+
+Si la URL no contiene ningún alias, se usa como URL absoluta directamente.
+
+### Override
+
+Permite especificar una URL alternativa para cartas puntuales cuya imagen no sigue el patrón general del set (típicamente erratas):
+
+```js
+"override": {
+    "url": "bandaitcgplusURL/BT21/e_setID-cardID_d_errata.png",
+    "cards": {
+        "BT21-023": "",  // El valor puede ser un parallel alternativo o vacío
+    }
+}
+```
+
+### Parallel
+
+En los sets con `id: null`, el campo `cards` mapea cada número de carta a su valor de parallel:
+
+| Valor | Significado |
+|-------|-------------|
+| `""` | Sin sufijo parallel en la URL |
+| `"P1"`, `"_d"`, `"SP"`, etc. | Sufijo que se inserta en el placeholder `parallel` de la URL |
+| `["P1", "P2"]` | Múltiples variantes paralelas de la misma carta (ej. foil y no foil). Genera una imagen por cada elemento del array |
+
+---
+
+## Color
+
+Define el color primario (y secundario/terciario) de cada carta. Se usa para el fondo visual de la celda de ID y para el filtro de color.
+
+**Si es un `string`:** Todas las cartas del set tienen ese color.
+
+```js
+"color": "red"
+```
+
+**Si es un `object`:** Mapa de color → array de IDs de carta.
+
+```js
+"color": {
+    "red": [1, 8, 10, 13, 65],
+    "red-blue": [73],
+    "blue": [2, 17, 18, 20],
+    "yellow-purple": [62, 64],
+}
+```
+
+Los IDs pueden ser números individuales o rangos como strings: `"30-32"` se expande a `[30, 31, 32]`.
+
+Colores soportados: `red`, `blue`, `yellow`, `green`, `black`, `purple`, `white`. Los multicolor se separan con guión: `"red-blue"`, `"yellow-purple-black"`.
+
+---
+
+## Rareza
+
+Define la rareza de cada carta. Funciona igual que el color.
+
+**Si es un `string`:** Todas las cartas del set tienen esa rareza.
+
+```js
+"rarity": "p"  // Todas son promos
+```
+
+**Si es un `object`:** Mapa de rareza → array de IDs.
+
+```js
+"rarity": {
+    "c": [3, 8, 10, 12],
+    "u": [1, 2, "4-7"],
+    "r": [9, 11],
+    "sr": [16, 26],
+    "sec": [73, 74],
+}
+```
+
+Rarezas soportadas:
+
+| Código | Nombre |
+|--------|--------|
+| `c` | Common |
+| `u` | Uncommon |
+| `r` | Rare |
+| `sr` | Super Rare |
+| `sec` | Secret Rare |
+| `p` | Promo |
+| `aa` | Alternative Art (valor por defecto si no se especifica) |
+| `sp` | Special |
+| `t` | Token |
+
+### `rarities` (multi-set)
+
+Cuando un set con `id: null` inyecta cartas en múltiples sets base, se usa `rarities` en lugar de `rarity`:
+
+```js
+"rarities": {
+    "BT19": "sp",           // Todas las de BT19 son SP
+    "BT20": {               // Las de BT20 tienen rarezas individuales
+        "sp": [21, 45, 60]
+    }
+}
+```
+
+---
+
+## Bloques y reprints
+
+### Concepto de bloque
+
+Un bloque (`block`) representa el periodo temporal en el que se imprimieron las cartas:
+
+| Bloque | Periodo | Sets de referencia |
+|--------|---------|-------------------|
+| 0 | 2020 (sin icono) | ST1–ST6, BT1–BT5 |
+| 1 | 2021 | ST7–ST10, BT6–BT9, EX1–EX2 |
+| 2 | 2022 | ST12–ST14, BT10–BT13, EX3–EX4 |
+| 3 | 2023 | ST15–ST17, BT14–BT17, EX5–EX6, RB1, LM |
+| 4 | 2024 | ST18–ST19, BT18–BT20, EX7–EX8 |
+| 5 | 2025 | ST20–ST22, BT21–BT23, EX9–EX10, AD1 |
+| 6 | 2026 | ST23+, BT24+, EX11+ |
+
+### Objetivo
+
+Todas las cartas deben tener un bloque asignado. Esto permite:
+
+- **Filtrar por bloque:** Mostrar solo las cartas de un periodo concreto.
+- **Inputs de cantidad por bloque:** Al filtrar por bloque X, se muestran las cartas de ese bloque y solo el input de cantidad correspondiente a ese bloque.
+
+### Block en sets base
+
+Todos los sets con `id` llevan `"block"` indicando a qué periodo pertenecen:
+
+```js
+{
+    "id": "BT21",
+    "block": 5,
+    "slug": "bt21",
+    "name": "Booster World Convergence [BT21]",
+    ...
+}
+```
+
+### Block en sets con cartas de distintos bloques
+
+Cuando un set contiene cartas de distintos bloques (ej. Promos, o productos que mezclan sets de distintos periodos), `block` se define como un mapa bloque → cartas:
+
+```js
+"block": {
+    "0": ["1-20"],
+    "1": ["21-50"],
+    "2": ["51-80"],
+    ...
+}
+```
+
+Esto aplica a:
+- **Promos** (`"id": "P"`) — cada carta puede pertenecer a un bloque distinto.
+- **Sets sin ID** que inyectan cartas de distintos periodos en un mismo producto.
+
+### Definición de reprint
+
+**Reprint = cualquier reimpresión de una carta posterior a su publicación original.** Esto incluye:
+
+- Arts alternativos publicados en bloques posteriores.
+- Cambios de bloque (misma carta reimpresa en un producto de otro periodo).
+- Cualquier otra variante que se publique después de la original.
+
+Se mantiene el tracking de cantidad por bloque para un posible futuro sistema de rotación (jugar solo determinados bloques).
+
+### Cómo se define un reprint
+
+```js
+{
+    "id": null,
+    "slug": "st22_reprint",
+    "name": "Advanced Deck Amethyst Mandala [ST-22] - reprints",
+    "url": "bandaitcgplusURL/ST22/e_setID-cardID_D.png",
+    "cards": {
+        "BT17-031": "",
+        "BT17-035": "",
+        "BT19-034": "",
+    },
+    "reprint": true,
+    "block": 5,
+}
+```
+
+En la UI, las cartas con reprints muestran inputs adicionales en la columna de cantidad, uno por cada bloque de reprint, para trackear cuántas copias se tienen de cada impresión.
+
+---
+
+## Slug y relación set-producto
+
+El `slug` identifica el producto o release al que pertenece un set. Es la conexión entre los datos estáticos y la colección del usuario.
+
+### Casos especiales
+
+Algunos sets base (`id` no nulo) no tienen `slug` porque sus cartas no se vendieron directamente en un producto propio:
+
+| Set | Motivo |
+|-----|--------|
+| `P` (Promos) | Las promos se distribuyen en muchos productos distintos (torneos, eventos, packs). No hay un producto "Promos". |
+| `BT1`, `BT2`, `BT3` | Se comercializaron mezclados en dos productos: Special Booster Ver.1.0 (`sbt10`) y Special Booster Ver.1.5 (`sbt15`). |
+| `LM` | Se publica en distintos productos a lo largo del tiempo (Limited Card Packs). |
+| `BT18`, `BT19`, `BT20` | Se aunaron en dos productos mezclando cartas de los tres: Special Booster Ver.2.0 y Ver.2.5. |
+
+En estos casos, los sets con `id: null` que inyectan sus cartas sí tienen `slug` apuntando al producto concreto.
+
+---
+
+## Productos
+
+Los productos (sobres, cajas, etc.) se definen mediante el campo `pack` en los sets:
+
+```js
+// Un solo sobre
+"pack": "https://...imagen_sobre.png"
+
+// Múltiples variantes de sobre
+"pack": [
+    "https://...sobre_variante_1.png",
+    "https://...sobre_variante_2.png",
+]
+```
+
+Actualmente solo se gestionan sobres, pero la estructura está pensada para expandirse a: cajas, fundas, tapetes, contadores de memoria, deckbox y cualquier otro producto relacionado.
+
+---
+
+## Estados de carta
+
+Cada variante de carta tiene un estado numérico:
+
+| Valor | Estado | Descripción |
+|-------|--------|-------------|
+| `-1` | Reservada | Carta apartada/reservada pendiente de recibir |
+| `0` | Falta | No se tiene (estado por defecto) |
+| `1` | Obtenida | Se tiene la carta |
+| `2` | Comprada | Se compró (requiere precio) |
+| `3` | Proxy | Se tiene una copia proxy (requiere precio) |
+
+### ¿Por qué `-1` para reservada?
+
+El valor negativo permite usar `status > 1` como condición para determinar si una carta tiene precio asociado (comprada o proxy), excluyendo automáticamente falta (0), obtenida (1) y reservada (-1) sin necesidad de condiciones adicionales. También se aprovecha en el modal de visualización, donde el array `['Falta', 'Obtenida', 'Comprada', 'Proxy']` no tiene índice `-1`, cayendo al fallback `'Reservada'`.
+
+> **Nota:** Esta lógica está en consideración de cambio. Cuando se reserva una carta normalmente ya se conoce el precio, por lo que tendría sentido permitir registrar un precio en estado reservada. Sin embargo, si la carta se obtiene por intercambio no habría precio, similar a "obtenida". Por esta ambigüedad, la lógica se ha mantenido así hasta ahora.
+
+---
+
+## localStorage: collection
+
+Estructura del objeto `collection` almacenado en localStorage:
+
+```json
+{
+    "BT21": {
+        "001": {
+            "amount": 4,
+            "cards": {
+                "bt21": { "status": 1, "bought": 0 },
+                "bt21_alts": { "status": 2, "bought": 3.50 },
+                "bt21_special": { "status": 0, "bought": 0 }
+            },
+            "reprint": {
+                "5": 2
+            }
+        },
+        "002": {
+            "amount": 0,
+            "cards": {
+                "bt21": { "status": 0, "bought": 0 }
+            }
+        }
+    },
+    "products": {
+        "packs": {
+            "bt21": { "status": 1, "bought": 0 },
+            "sbt10_0": { "status": 2, "bought": 15.00 }
+        }
+    }
+}
+```
+
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| `[setId][cardId].amount` | `number` | Cantidad total de copias de esa carta (todas las variantes) |
+| `[setId][cardId].cards[slug]` | `object` | Estado y precio de cada variante, indexado por `slug` del set de origen |
+| `[setId][cardId].cards[slug].status` | `number` | Estado de la carta (-1, 0, 1, 2, 3) |
+| `[setId][cardId].cards[slug].bought` | `number` | Precio de compra (solo si status > 1) |
+| `[setId][cardId].reprint` | `object` | Opcional. Cantidad de copias por bloque de reprint: `{ "5": 2 }` |
+| `products.packs[slug]` | `object` | Estado y precio de cada sobre/producto |
+
+---
+
+## localStorage: cardmarket
+
+Estructura del objeto `cardmarket` almacenado en localStorage:
+
+```json
+{
+    "BT21": {
+        "001": {
+            "bt21_alts": {
+                "url": "https://www.cardmarket.com/en/DigimonCardGame/Products/...",
+                "price": [4.50, 3.80, 3.20]
+            }
+        }
+    },
+    "products": {
+        "packs": {
+            "bt21": {
+                "url": "https://...",
+                "price": [89.99]
+            }
+        }
+    }
+}
+```
+
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| `[setId][cardId][slug].url` | `string` | URL de la carta en Cardmarket |
+| `[setId][cardId][slug].price` | `number[]` | Historial de precios mínimos. Cada vez que se introduce un precio distinto al último, se añade al array. Permite ver la evolución del precio en el tiempo. |
+| `products.packs[slug]` | `object` | Misma estructura para productos |
+
+---
+
+## Decisiones de diseño
+
+| Decisión | Motivo |
+|----------|--------|
+| Datos en JS en lugar de JSON | Permite declararlos como variables globales sin necesidad de fetch/import. Simplifica el setup sin bundler. |
+| localStorage como persistencia | Sin backend, sin cuentas. Los datos son del usuario y viven en su navegador. |
+| `id: null` para variantes | Permite reutilizar la misma tabla HTML del set base, inyectando imágenes adicionales en las filas existentes. |
+| Historial de precios como array | Permite trackear la evolución del precio de Cardmarket sin complejidad adicional. Solo se añade un nuevo valor si difiere del último. |
+| Separación `collection` / `cardmarket` | Son datos con ciclos de vida distintos: la colección cambia cuando el usuario edita, los precios de Cardmarket cambian con el mercado. Permite exportarlos/importarlos por separado. |
+| Reprints indexados por bloque | Una misma carta puede tener reprints en distintos bloques temporales. Indexar por bloque permite saber cuántas copias se tienen de cada impresión. |

--- a/FRAMEWORKS.md
+++ b/FRAMEWORKS.md
@@ -1,0 +1,276 @@
+# Análisis de componentización y frameworks — DTCG Web Collection
+
+## Índice
+
+- [Estado actual del proyecto](#estado-actual-del-proyecto)
+- [¿Componentizar? Sí, pero no necesariamente con un framework](#componentizar-sí-pero-no-necesariamente-con-un-framework)
+- [Opción 1: Componentizar en vanilla JS (recomendada ahora)](#opción-1-componentizar-en-vanilla-js-recomendada-ahora)
+- [Opción 2: Migrar a un framework (futuro)](#opción-2-migrar-a-un-framework-futuro)
+- [Comparativa de frameworks](#comparativa-de-frameworks)
+- [Cuándo reconsiderar la migración](#cuándo-reconsiderar-la-migración)
+- [Conclusión](#conclusión)
+
+---
+
+## Estado actual del proyecto
+
+El proyecto tiene una ventaja enorme: **cero dependencias de runtime**. Es HTML + JS vanilla + SASS. Se sirve con un `http-server` y los datos viven en localStorage.
+
+Eso es muy valioso:
+
+- ✅ Simplicidad — No hay build complejo ni abstracciones innecesarias.
+- ✅ Velocidad de carga — Sin bundle de framework (~0KB de JS de terceros).
+- ✅ Sin lock-in — No estás atado a ningún ecosistema.
+- ✅ Fácil de desplegar — Cualquier servidor estático sirve.
+
+---
+
+## ¿Componentizar? Sí, pero no necesariamente con un framework
+
+Se puede obtener el 80% de los beneficios de un framework sin migrar. La clave está en aplicar patrones de componentización sobre vanilla JS.
+
+---
+
+## Opción 1: Componentizar en vanilla JS (recomendada ahora)
+
+### 1.1 Módulos ES
+
+El primer paso y el más impactante. Pasar de scripts globales a `import`/`export`:
+
+```
+js/
+├── data/                  # Sin cambios
+├── store/
+│   ├── collection.js      # CRUD sobre localStorage (collection)
+│   └── cardmarket.js      # CRUD sobre localStorage (cardmarket)
+├── components/
+│   ├── card-item.js       # Genera el HTML de una carta
+│   ├── card-modal.js      # Lógica del modal de edición/visualización
+│   ├── set-table.js       # Genera la tabla de un set
+│   ├── set-buttons.js     # Botones de navegación de sets
+│   ├── filters.js         # Barra de filtros
+│   └── toast.js           # Notificaciones tipo snackbar
+├── utils/
+│   ├── url-resolver.js    # getImageUrl y lógica de URLs
+│   ├── range-expander.js  # Expandir rangos "1-5" a [1,2,3,4,5]
+│   └── constants.js       # Estados, colores, rarezas
+├── app.js                 # Punto de entrada (importa todo)
+└── sets.js                # Concatena datos (sin cambios)
+```
+
+```html
+<!-- index.html — un solo script -->
+<script type="module" src="js/app.js"></script>
+```
+
+### 1.2 Web Components (opcional)
+
+Encapsular piezas reutilizables como Custom Elements:
+
+```js
+// components/card-item.js
+class CardItem extends HTMLElement {
+    static observedAttributes = ['status', 'bought'];
+
+    connectedCallback() {
+        this.render();
+        this.addEventListener('click', () => this.openModal());
+    }
+
+    attributeChangedCallback() {
+        this.render();
+    }
+
+    render() {
+        const status = this.getAttribute('status');
+        // ...
+    }
+}
+
+customElements.define('card-item', CardItem);
+```
+
+```html
+<!-- Uso en el DOM -->
+<card-item
+    card-id="BT15-042"
+    slug="bt15"
+    status="1"
+    bought="3.50"
+    src="https://...">
+</card-item>
+```
+
+**Ventajas:**
+
+- Encapsulación nativa del navegador.
+- Sin dependencias.
+- Compatible con cualquier framework futuro.
+
+**Desventajas:**
+
+- Más verboso que un framework.
+- Sin reactividad automática (hay que gestionar manualmente los re-renders).
+
+### 1.3 Store reactivo simple
+
+Un patrón pub/sub ligero para gestionar el estado sin framework:
+
+```js
+// store/collection.js
+const listeners = new Set();
+
+const store = {
+    data: JSON.parse(localStorage.getItem('collection') || '{}'),
+
+    get(setId, cardId) {
+        return this.data[setId]?.[cardId];
+    },
+
+    update(setId, cardId, slug, changes) {
+        Object.assign(this.data[setId][cardId].cards[slug], changes);
+        this.notify({ setId, cardId, slug, changes });
+    },
+
+    save() {
+        localStorage.setItem('collection', JSON.stringify(this.data));
+    },
+
+    subscribe(fn) {
+        listeners.add(fn);
+        return () => listeners.delete(fn);
+    },
+
+    notify(event) {
+        listeners.forEach(fn => fn(event));
+    }
+};
+
+export default store;
+```
+
+Esto permite que cualquier componente reaccione a cambios sin acoplamiento directo.
+
+### 1.4 Hoja de ruta para componentizar en vanilla
+
+| Paso | Descripción | Impacto |
+|------|-------------|---------|
+| 1 | Migrar a módulos ES (`import`/`export`) | 🔴 Alto |
+| 2 | Extraer `constants.js` y `url-resolver.js` | 🟠 Medio |
+| 3 | Crear `store/collection.js` y `store/cardmarket.js` | 🟠 Medio |
+| 4 | Separar la generación de DOM en `components/` | 🟠 Medio |
+| 5 | (Opcional) Migrar componentes clave a Web Components | 🟡 Bajo |
+
+---
+
+## Opción 2: Migrar a un framework (futuro)
+
+### Cuándo tendría sentido
+
+Solo si el proyecto evoluciona hacia alguno de estos escenarios:
+
+- **Cuentas de usuario** — Sincronización entre dispositivos, login.
+- **Compartir colecciones** — URLs públicas con vista de solo lectura.
+- **API de Cardmarket** — Consulta automática de precios.
+- **Colaboración** — Comparar colecciones entre usuarios, proponer intercambios.
+
+### Framework recomendado: Vue 3 + Vite
+
+Si llegara el momento de migrar, **Vue 3** es la opción más natural para este proyecto:
+
+- **Templates HTML** — La filosofía de Vue (templates declarativos) encaja con cómo ya está estructurado el proyecto. No hay que aprender JSX.
+- **Reactividad declarativa** — `ref()`, `computed()`, `watch()` reemplazan toda la manipulación manual del DOM.
+- **Componentes `.vue`** — Template + script + style en un archivo, mapea directamente a la separación actual.
+- **Vite** — Resuelve SASS, HMR, build y minificación de golpe (adiós Gulp).
+- **Curva de aprendizaje** — Más suave desde vanilla JS que React o Angular.
+
+#### Ejemplo de cómo se vería un componente
+
+```vue
+<!-- components/CardItem.vue -->
+<template>
+    <img
+        loading="lazy"
+        class="card"
+        :src="url"
+        :title="name"
+        :alt="name"
+        :data-status="card.status"
+        @click="$emit('open', cardId)"
+    />
+</template>
+
+<script setup>
+defineProps({
+    cardId: String,
+    name: String,
+    url: String,
+    card: Object,
+});
+
+defineEmits(['open']);
+</script>
+
+<style scoped>
+.card[data-status="1"] {
+    padding-right: 7px;
+    background-color: var(--correct-card);
+}
+</style>
+```
+
+---
+
+## Comparativa de frameworks
+
+| Criterio | Vanilla + Módulos | Vue 3 | React | Svelte | Angular |
+|----------|:-:|:-:|:-:|:-:|:-:|
+| Curva desde el código actual | ✅ Nula | ✅ Baja | 🟡 Media | ✅ Baja | 🔴 Alta |
+| Peso del bundle | ✅ 0KB | 🟡 ~33KB | 🟡 ~40KB | ✅ ~5KB | 🔴 ~80KB+ |
+| Reactividad | ❌ Manual | ✅ Nativa | ✅ Nativa | ✅ Nativa | ✅ Nativa |
+| Ecosistema/plugins | ❌ Limitado | ✅ Amplio | ✅ Muy amplio | 🟡 Creciendo | ✅ Muy amplio |
+| Complejidad de setup | ✅ Ninguna | 🟡 Vite | 🟡 Vite/CRA | 🟡 Vite | 🔴 CLI propio |
+| SSR/SSG (si se necesita) | ❌ No | ✅ Nuxt | ✅ Next.js | ✅ SvelteKit | ✅ Angular Universal |
+| Afinidad con el proyecto | ✅ Total | ✅ Alta | 🟡 Media | ✅ Alta | 🟡 Baja |
+
+### ¿Por qué no React?
+
+- JSX requiere un cambio de mentalidad respecto a templates HTML.
+- El modelo de hooks y re-renders es más complejo para un proyecto de este tamaño.
+- No aporta ventajas significativas sobre Vue para este caso de uso.
+
+### ¿Por qué no Angular?
+
+- Demasiado pesado y opinionado para una app de coleccionismo personal.
+- TypeScript obligatorio, decoradores, inyección de dependencias... overhead innecesario aquí.
+
+### ¿Por qué no Svelte?
+
+- Sería una buena opción (bundle mínimo, sintaxis simple).
+- Pero el ecosistema es más pequeño y la comunidad hispanohablante es reducida.
+- Si el proyecto crece, Vue tiene más recursos y plugins disponibles.
+
+---
+
+## Cuándo reconsiderar la migración
+
+Checklist para saber si ha llegado el momento:
+
+- [ ] El código vanilla componentizado se vuelve difícil de mantener (>2000 líneas en un solo archivo).
+- [ ] Necesitas routing real (múltiples páginas/vistas).
+- [ ] Necesitas un backend con autenticación.
+- [ ] Necesitas SSR para compartir colecciones con preview en redes sociales.
+- [ ] La manipulación manual del DOM se convierte en el cuello de botella del desarrollo.
+- [ ] Quieres contribuciones de otros desarrolladores (un framework estandariza patrones).
+
+Si marcas 3+ de estos puntos, es momento de migrar.
+
+---
+
+## Conclusión
+
+**Ahora:** Invertir en las mejoras del [IMPROVEMENTS.md](IMPROVEMENTS.md), especialmente en modularizar con ES modules y separar responsabilidades. Esto ya es componentizar, solo que sin framework.
+
+**Futuro:** Si el proyecto crece hacia funcionalidades sociales (compartir, cuentas, API), migrar a **Vue 3 + Vite** sería la transición más natural y menos dolorosa desde el código actual.
+
+La mejor migración es la que no necesitas hacer. Y ahora mismo, no la necesitas.

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -1,0 +1,710 @@
+# Sugerencias de mejora — DTCG Web Collection
+
+## Prioridad sugerida
+
+| Prioridad | Items |
+|-----------|-------|
+| 🔴 Alta | [1](#item-1), [5](#item-5), [7](#item-7), [19](#item-19), [33](#item-33), [38](#item-38), [64](#item-64) |
+| 🟠 Media | [2](#item-2), [3](#item-3), [4](#item-4), [8](#item-8), [10](#item-10), [12](#item-12), [16](#item-16), [17](#item-17), [18](#item-18), [20](#item-20), [27](#item-27), [29](#item-29), [39](#item-39), [40](#item-40), [68](#item-68), [73](#item-73) |
+| 🟡 Baja | [6](#item-6), [9](#item-9), [11](#item-11), [13](#item-13), [14](#item-14), [15](#item-15), [21](#item-21)–[26](#item-26), [28](#item-28), [30](#item-30)–[32](#item-32), [34](#item-34)–[37](#item-37), [41](#item-41)–[67](#item-67), [69](#item-69)–[72](#item-72), [74](#item-74) |
+
+---
+
+## Índice
+
+- [🔧 Refactorización de código](#-refactorización-de-código)
+- [🏗️ Arquitectura](#️-arquitectura)
+- [🎨 UX/UI](#-uxui)
+- [⚡ Rendimiento](#-rendimiento)
+- [🔒 Robustez y datos](#-robustez-y-datos)
+- [🧪 Calidad y testing](#-calidad-y-testing)
+- [📦 Build y tooling](#-build-y-tooling)
+- [🌐 SEO y PWA](#-seo-y-pwa)
+- [💡 Funcionalidades nuevas](#-funcionalidades-nuevas)
+
+---
+
+## 🔧 Refactorización de código
+
+<a id="item-1"></a>
+
+### 1. Eliminar `var` y usar `const`/`let` <sup>[↑](#prioridad-sugerida)</sup>
+
+En `index.js` hay varios `var cardUrl` dentro de bloques `if/else`. Esto causa hoisting y puede generar bugs sutiles. Reemplazarlos por `let cardUrl` declarado antes del `if`.
+
+```js
+// ❌ Actual
+if (url.includes('bandaitcgplusURL')) {
+    var cardUrl = url.replace('bandaitcgplusURL', bandaitcgplusURL);
+} else if (...) {
+    var cardUrl = ...;
+}
+
+// ✅ Propuesto
+let cardUrl;
+if (url.includes('bandaitcgplusURL')) {
+    cardUrl = url.replace('bandaitcgplusURL', bandaitcgplusURL);
+} else if (...) {
+    cardUrl = ...;
+}
+```
+
+<a id="item-2"></a>
+
+### 2. Simplificar `getImageUrl` con un mapa de URLs base <sup>[↑](#prioridad-sugerida)</sup>
+
+La cadena de `if/else if` para resolver URLs base se puede simplificar con un objeto:
+
+```js
+const urlBases = {
+    bandaitcgplusURL: 'https://files.bandai-tcg-plus.com/card_image/DG-EN',
+    digimoncardjpURL: 'https://digimoncard.com/images/cardlist/card',
+    digimoncardURL: 'https://world.digimoncard.com/images/cardlist/card',
+    digimonCardDev: 'https://assets.cardlist.dev/images/communitycards',
+    digimonFandom: 'https://static.wikia.nocookie.net/digimoncardgame/images',
+};
+
+let cardUrl = url;
+for (const [key, base] of Object.entries(urlBases)) {
+    if (url.includes(key)) {
+        cardUrl = url.replace(key, base);
+        break;
+    }
+}
+```
+
+<a id="item-3"></a>
+
+### 3. Reducir duplicación en `drawAlternatives` <sup>[↑](#prioridad-sugerida)</sup>
+
+La lógica de "si no existe la carta, crearla" y "si hay override, recalcular URL" se repite en 3-4 sitios. Extraer funciones auxiliares:
+
+- `ensureCardExists(setId, cardId, slug)` — Inicializa la carta en `collection` si no existe.
+- `resolveCardUrl(setElement, url, setId, cardId, parallel)` — Resuelve la URL final teniendo en cuenta overrides.
+
+<a id="item-4"></a>
+
+### 4. Reducir duplicación en `modalOk` <sup>[↑](#prioridad-sugerida)</sup>
+
+La lógica de guardar el precio de Cardmarket se repite casi idéntica para `card` y `pack`. Extraer a una función:
+
+```js
+const updateCardmarketPrice = (target, price) => {
+    target.price ??= [];
+    if (target.price.length === 0 || target.price.slice(-1)[0] !== price) {
+        target.price.push(price);
+    }
+};
+```
+
+<a id="item-5"></a>
+
+### 5. Eliminar `innerHTML +=` para inyectar imágenes <sup>[↑](#prioridad-sugerida)</sup>
+
+Cada vez que se hace `innerHTML +=` en `card_list`, el navegador re-parsea todo el HTML existente de esa celda, destruyendo event listeners y forzando re-renders innecesarios. Usar `insertAdjacentHTML('beforeend', ...)` o crear elementos con `document.createElement`.
+
+<a id="item-6"></a>
+
+### 6. Eliminar `onclick` inline en HTML <sup>[↑](#prioridad-sugerida)</sup>
+
+Hay muchos `onclick="editSet()"`, `onclick="modalClose(this)"`, etc. en `index.html`. Usar `addEventListener` desde JS para mantener la separación HTML/JS y facilitar el testing.
+
+<a id="item-7"></a>
+
+### 7. Evitar `this.event` en `selectValue` <sup>[↑](#prioridad-sugerida)</sup>
+
+```js
+// ❌ Actual — this.event es legacy y no funciona en strict mode
+const selectValue = () => {
+    if (editingSet) {
+        this.event.target.select();
+    }
+}
+
+// ✅ Propuesto
+const selectValue = (e) => {
+    if (editingSet) {
+        e.target.select();
+    }
+}
+```
+
+<a id="item-8"></a>
+
+### 8. Unificar la lógica de expansión de rangos <sup>[↑](#prioridad-sugerida)</sup>
+
+`getCardsColor` y `getCardsRarity` comparten la misma lógica de expandir rangos tipo `"1-5"` a índices individuales. Extraer a una función genérica:
+
+```js
+const expandRanges = (mapping) => {
+    const result = [];
+    Object.entries(mapping).forEach(([value, ids]) => {
+        ids.forEach(id => {
+            if (typeof id === 'string') {
+                const [start, end] = id.split('-').map(Number);
+                for (let i = start; i <= end; i++) result[i] = value;
+            } else {
+                result[id] = value;
+            }
+        });
+    });
+    return result;
+};
+```
+
+<a id="item-9"></a>
+
+### 9. Usar template literals consistentemente <sup>[↑](#prioridad-sugerida)</sup>
+
+En `views.js` se usa concatenación con `+` para construir clases CSS:
+
+```js
+// ❌
+setLists.classList.add('view--' + list);
+
+// ✅
+setLists.classList.add(`view--${list}`);
+```
+
+---
+
+## 🏗️ Arquitectura
+
+<a id="item-10"></a>
+
+### 10. Migrar a módulos ES <sup>[↑](#prioridad-sugerida)</sup>
+
+Actualmente se cargan 10+ scripts con `<script>` globales. Usar `type="module"` e `import`/`export` eliminaría la dependencia del orden de carga y las variables globales (`collection`, `cardmarket`, `editingSet`, etc.).
+
+<a id="item-11"></a>
+
+### 11. Separar datos de presentación <sup>[↑](#prioridad-sugerida)</sup>
+
+`index.js` mezcla lógica de negocio (gestión de colección/localStorage) con generación de DOM. Separar en:
+
+- `collection.js` — Solo gestiona el estado (CRUD sobre localStorage).
+- `renderer.js` — Solo dibuja el DOM a partir del estado.
+
+<a id="item-12"></a>
+
+### 12. Sistema de versiones para migraciones <sup>[↑](#prioridad-sugerida)</sup>
+
+En `updates.js` ya existe el TODO. Implementar un `dataVersion` en localStorage y un array de migraciones secuenciales:
+
+```js
+const CURRENT_VERSION = 5;
+const migrations = [
+    { version: 1, fn: () => { /* LM01 -> LM */ } },
+    { version: 2, fn: () => { /* migrateReprints */ } },
+    // ...
+];
+
+const runMigrations = () => {
+    let version = parseInt(localStorage.getItem('dataVersion') || '0');
+    for (const m of migrations) {
+        if (version < m.version) {
+            m.fn();
+            version = m.version;
+        }
+    }
+    localStorage.setItem('dataVersion', String(CURRENT_VERSION));
+};
+```
+
+<a id="item-13"></a>
+
+### 13. Crear una clase `Card` <sup>[↑](#prioridad-sugerida)</sup>
+
+Como indica el TODO en `index.js`, pasar a un modelo orientado a objetos para las cartas simplificaría mucho la lógica:
+
+```js
+class Card {
+    constructor({ setId, cardId, slug, url, status, bought, rarity }) { ... }
+    getImageUrl() { ... }
+    toHTML() { ... }
+    updateStatus(status, price) { ... }
+}
+```
+
+<a id="item-14"></a>
+
+### 14. Centralizar constantes <sup>[↑](#prioridad-sugerida)</sup>
+
+Los mapas de estado (`0=falta, 1=obtenida, -1=reservada...`) se repiten en `modal.js` y `filters.js` con formatos distintos. Centralizar en un único archivo de constantes.
+
+<a id="item-15"></a>
+
+### 15. Separar los datos de sets en JSON <sup>[↑](#prioridad-sugerida)</sup>
+
+Los archivos `data_*.js` son scripts que declaran variables globales. Si fueran archivos `.json`, podrían cargarse dinámicamente (fetch o import) y serían más fáciles de validar, generar automáticamente y versionar.
+
+---
+
+## 🎨 UX/UI
+
+<a id="item-16"></a>
+
+### 16. Feedback visual al guardar <sup>[↑](#prioridad-sugerida)</sup>
+
+Cuando se pulsa "Guardar", no hay confirmación visual. Un toast/snackbar temporal ("Colección guardada ✓") daría confianza al usuario.
+
+<a id="item-17"></a>
+
+### 17. Confirmación antes de cancelar edición <sup>[↑](#prioridad-sugerida)</sup>
+
+Si el usuario ha hecho cambios y pulsa "Cancelar", se pierden sin aviso. Un `confirm()` simple evitaría pérdidas accidentales.
+
+<a id="item-18"></a>
+
+### 18. Diseño responsive <sup>[↑](#prioridad-sugerida)</sup>
+
+No hay media queries significativas fuera del modal. En móvil, la barra de filtros, botones de sets y la tabla se ven apretados. Considerar:
+
+- Layout colapsable para filtros en pantallas pequeñas.
+- Botones de sets en scroll horizontal.
+- Vista grid como default en móvil.
+
+<a id="item-19"></a>
+
+### 19. Accesibilidad <sup>[↑](#prioridad-sugerida)</sup>
+
+- `<html lang="en">` debería ser `lang="es"` ya que la UI está en español.
+- Los botones `<` y `>` de navegación de sets no tienen texto accesible (solo `title`), añadir `aria-label`.
+- Los radio buttons del modal usan solo iconos SVG sin texto visible; asegurar que los `title` en los `<label>` sean suficientes o añadir `aria-label`.
+- Añadir `role="dialog"` y `aria-modal="true"` a los modales.
+- Gestionar el foco al abrir/cerrar modales (focus trap).
+
+<a id="item-20"></a>
+
+### 20. Atajos de teclado en el modal <sup>[↑](#prioridad-sugerida)</sup>
+
+- Cerrar con `Escape`.
+- Confirmar con `Enter`.
+- Navegar entre estados con flechas izquierda/derecha.
+
+<a id="item-21"></a>
+
+### 21. Indicador de progreso de colección <sup>[↑](#prioridad-sugerida)</sup>
+
+Una barra o porcentaje por set (ej. "BT15: 87/112 — 78%") sería muy útil para ver de un vistazo cuánto falta. Podría mostrarse en los botones de set o como tooltip.
+
+<a id="item-22"></a>
+
+### 22. Tema oscuro <sup>[↑](#prioridad-sugerida)</sup>
+
+Dado que es una app de coleccionismo que se usa mucho tiempo, un dark mode reduciría fatiga visual. Se puede implementar con CSS custom properties y un toggle.
+
+<a id="item-23"></a>
+
+### 23. Mejorar la vista grid <sup>[↑](#prioridad-sugerida)</sup>
+
+Actualmente la vista grid solo oculta columnas de la tabla. Podría ser un layout CSS Grid real con las imágenes de cartas más grandes y con indicadores de estado superpuestos (badges).
+
+<a id="item-24"></a>
+
+### 24. Indicadores visuales en botones de set <sup>[↑](#prioridad-sugerida)</sup>
+
+Mostrar en cada botón de set un indicador de completitud (ej. un punto verde si está completo, amarillo si está en progreso, rojo si no se ha empezado).
+
+<a id="item-25"></a>
+
+### 25. Mejorar la impresión <sup>[↑](#prioridad-sugerida)</sup>
+
+El CSS de impresión es muy básico. Podría incluir:
+
+- Resumen de colección por set.
+- Lista de cartas que faltan.
+- Totales de gasto por set.
+
+<a id="item-26"></a>
+
+### 26. Swipe en móvil para navegar entre sets <sup>[↑](#prioridad-sugerida)</sup>
+
+En dispositivos táctiles, permitir deslizar izquierda/derecha para cambiar de set, similar a la navegación con los botones `<` y `>`.
+
+---
+
+## ⚡ Rendimiento
+
+<a id="item-27"></a>
+
+### 27. Carga diferida de sets (lazy rendering) <sup>[↑](#prioridad-sugerida)</sup>
+
+Actualmente se generan TODAS las tablas de TODOS los sets al cargar la página. Con 20+ sets y cientos de cartas cada uno, el DOM inicial es enorme. Generar las tablas solo cuando el usuario selecciona un set.
+
+<a id="item-28"></a>
+
+### 28. Debounce en filtros <sup>[↑](#prioridad-sugerida)</sup>
+
+Si el usuario cambia filtros rápidamente, cada cambio ejecuta `filterCards()` que recorre todo el DOM. Un debounce de ~150ms evitaría trabajo innecesario.
+
+<a id="item-29"></a>
+
+### 29. Reducir el tamaño de localStorage <sup>[↑](#prioridad-sugerida)</sup>
+
+Como indica el TODO existente, no almacenar cartas con estado por defecto (`{status: 0, bought: 0}`) reduciría significativamente el JSON almacenado. Solo guardar las cartas que el usuario ha modificado.
+
+<a id="item-30"></a>
+
+### 30. Usar `DocumentFragment` para inserciones masivas <sup>[↑](#prioridad-sugerida)</sup>
+
+En el bucle principal de `sets.forEach`, cada `setLists.appendChild(tableSet)` causa un reflow. Acumular en un `DocumentFragment` y hacer un solo append al final.
+
+<a id="item-31"></a>
+
+### 31. Optimizar `filterCards` <sup>[↑](#prioridad-sugerida)</sup>
+
+`filterCards` limpia y re-aplica todos los filtros cada vez. Podría mantener un estado de filtros activos y solo recalcular lo que cambió. Además, usar `requestAnimationFrame` para agrupar cambios de DOM.
+
+<a id="item-32"></a>
+
+### 32. Considerar virtualización para "todas las colecciones" <sup>[↑](#prioridad-sugerida)</sup>
+
+Cuando se muestra "todas las colecciones" a la vez, el DOM puede tener miles de filas. Una librería de virtualización (o implementación propia) renderizaría solo las filas visibles.
+
+---
+
+## 🔒 Robustez y datos
+
+<a id="item-33"></a>
+
+### 33. Importar colección desde JSON <sup>[↑](#prioridad-sugerida)</sup>
+
+Hay exportación pero no importación. Si el usuario cambia de navegador o borra localStorage, pierde todo. Un botón "Importar colección" complementaría al de descarga.
+
+<a id="item-34"></a>
+
+### 34. Validación de datos importados <sup>[↑](#prioridad-sugerida)</sup>
+
+Si se implementa importación, validar la estructura del JSON antes de escribir en localStorage para evitar corrupción de datos.
+
+<a id="item-35"></a>
+
+### 35. Manejo de errores en `getImageUrl` <sup>[↑](#prioridad-sugerida)</sup>
+
+Si la URL no coincide con ningún patrón conocido, cae al `else` con `digimonFandom` por defecto, lo cual puede generar URLs rotas silenciosamente. Añadir un log de warning o un fallback visual.
+
+<a id="item-36"></a>
+
+### 36. Backup automático en localStorage <sup>[↑](#prioridad-sugerida)</sup>
+
+Guardar una copia de seguridad periódica (ej. `collection_backup`) con timestamp. Si la colección principal se corrompe, poder restaurar desde el backup.
+
+<a id="item-37"></a>
+
+### 37. Detectar y avisar sobre límite de localStorage <sup>[↑](#prioridad-sugerida)</sup>
+
+localStorage tiene un límite de ~5-10MB. Con una colección grande y muchos datos de Cardmarket, podría alcanzarse. Detectar el tamaño actual y avisar al usuario cuando se acerque al límite.
+
+<a id="item-38"></a>
+
+### 38. Proteger contra pérdida de datos al editar <sup>[↑](#prioridad-sugerida)</sup>
+
+Actualmente, si el usuario cierra el navegador sin pulsar "Guardar", pierde los cambios de la sesión de edición. Considerar auto-guardado o guardar en cada `modalOk`.
+
+<a id="item-39"></a>
+
+### 39. Sanitizar URLs de Cardmarket <sup>[↑](#prioridad-sugerida)</sup>
+
+El campo `cardmarketUrl` acepta cualquier URL. Validar que sea una URL de `cardmarket.com` para evitar inyección de contenido malicioso vía `data-cardmarketurl`.
+
+---
+
+## 🧪 Calidad y testing
+
+<a id="item-40"></a>
+
+### 40. Añadir un linter (ESLint) <sup>[↑](#prioridad-sugerida)</sup>
+
+No hay configuración de linter. ESLint ayudaría a detectar problemas como el uso de `var`, variables no declaradas, etc.
+
+<a id="item-41"></a>
+
+### 41. Añadir tests unitarios <sup>[↑](#prioridad-sugerida)</sup>
+
+Las funciones puras como `getCardsColor`, `getCardsRarity`, `expandRanges` (si se extrae) son candidatas perfectas para tests unitarios con un framework ligero como Vitest.
+
+<a id="item-42"></a>
+
+### 42. Validar la integridad de los datos de sets <sup>[↑](#prioridad-sugerida)</sup>
+
+Crear un script que valide que todos los archivos `data_*.js` tienen la estructura correcta: campos obligatorios, rangos de cartas coherentes, URLs válidas, etc.
+
+<a id="item-43"></a>
+
+### 43. Añadir JSDoc a las funciones principales <sup>[↑](#prioridad-sugerida)</sup>
+
+Algunas funciones ya tienen comentarios, pero la mayoría no. JSDoc mejoraría la documentación y el autocompletado en el IDE.
+
+---
+
+## 📦 Build y tooling
+
+<a id="item-44"></a>
+
+### 44. Migrar de Gulp a un bundler moderno <sup>[↑](#prioridad-sugerida)</sup>
+
+Gulp solo se usa para compilar SASS. Un bundler como Vite o esbuild podría:
+
+- Compilar SASS.
+- Hacer bundle de los módulos JS.
+- Minificar CSS y JS para producción.
+- Hot reload en desarrollo.
+- Tree-shaking para eliminar código muerto.
+
+<a id="item-45"></a>
+
+### 45. Minificar CSS y JS para producción <sup>[↑](#prioridad-sugerida)</sup>
+
+Actualmente el CSS compilado no está minificado (el `style.css` generado tiene ~1200 líneas). Añadir un paso de minificación reduciría el tamaño de carga.
+
+<a id="item-46"></a>
+
+### 46. Añadir un `favicon.ico` <sup>[↑](#prioridad-sugerida)</sup>
+
+No hay favicon definido en el HTML. Añadir uno con el logo de la app o un icono de Digimon.
+
+<a id="item-47"></a>
+
+### 47. Generar source maps <sup>[↑](#prioridad-sugerida)</sup>
+
+Para facilitar el debugging en producción, generar source maps del CSS compilado.
+
+---
+
+## 🌐 SEO y PWA
+
+<a id="item-48"></a>
+
+### 48. Convertir en PWA (Progressive Web App) <sup>[↑](#prioridad-sugerida)</sup>
+
+Ya existe un `manifest.json` básico. Completarlo y añadir un Service Worker permitiría:
+
+- Uso offline (los datos ya están en localStorage).
+- Instalación como app nativa en móvil.
+- Caché de imágenes de cartas para carga más rápida.
+
+El `manifest.json` actual solo tiene `name` y `permissions`. Completar con:
+
+```json
+{
+    "name": "DTCG List",
+    "short_name": "DTCG",
+    "start_url": "/",
+    "display": "standalone",
+    "background_color": "#ffffff",
+    "theme_color": "#4285f4",
+    "icons": [...]
+}
+```
+
+<a id="item-49"></a>
+
+### 49. Añadir meta tags <sup>[↑](#prioridad-sugerida)</sup>
+
+```html
+<meta name="description" content="Gestiona tu colección de Digimon TCG">
+<meta name="theme-color" content="#4285f4">
+<link rel="manifest" href="manifest.json">
+```
+
+---
+
+## 💡 Funcionalidades nuevas
+
+<a id="item-50"></a>
+
+### 50. Búsqueda por nombre de carta <sup>[↑](#prioridad-sugerida)</sup>
+
+Actualmente solo se puede filtrar por set, color, estado y rareza. Buscar por nombre (ej. "Omnimon") sería muy práctico. Requeriría añadir el nombre de cada carta a los datos o al DOM.
+
+<a id="item-51"></a>
+
+### 51. Estadísticas de colección <sup>[↑](#prioridad-sugerida)</sup>
+
+Un panel de estadísticas con:
+
+- Total de cartas obtenidas vs total existente.
+- Gasto total y por set.
+- Distribución por estado (gráfico de tarta).
+- Evolución del gasto en el tiempo (usando el historial de precios de Cardmarket).
+- Set más completo / menos completo.
+
+<a id="item-52"></a>
+
+### 52. Historial de precios de Cardmarket <sup>[↑](#prioridad-sugerida)</sup>
+
+Ya se almacena un array de precios en `cardmarket[set][id][slug].price`. Mostrar un mini-gráfico de evolución de precio al hacer hover o en el modal de visualización.
+
+<a id="item-53"></a>
+
+### 53. Lista de deseos / wishlist <sup>[↑](#prioridad-sugerida)</sup>
+
+Permitir marcar cartas como "deseadas" para generar una lista de compra rápida con enlaces a Cardmarket.
+
+<a id="item-54"></a>
+
+### 54. Compartir colección <sup>[↑](#prioridad-sugerida)</sup>
+
+Generar un enlace o código que permita compartir la colección (o una vista de solo lectura) con otros coleccionistas. Podría ser un JSON codificado en base64 en la URL o un servicio externo.
+
+<a id="item-55"></a>
+
+### 55. Comparar colecciones <sup>[↑](#prioridad-sugerida)</sup>
+
+Permitir importar la colección de otro usuario y ver qué cartas tiene uno que le faltan al otro (y viceversa), útil para intercambios.
+
+<a id="item-56"></a>
+
+### 56. Notificaciones de nuevos sets <sup>[↑](#prioridad-sugerida)</sup>
+
+Cuando se añade un nuevo set a los datos, mostrar un badge o notificación al usuario indicando que hay contenido nuevo.
+
+<a id="item-57"></a>
+
+### 57. Modo "deck builder" ligero <sup>[↑](#prioridad-sugerida)</sup>
+
+Permitir seleccionar cartas de la colección para armar un deck de 50 cartas, con validación de reglas básicas (máximo 4 copias, etc.).
+
+<a id="item-58"></a>
+
+### 58. Integración con la API de Cardmarket <sup>[↑](#prioridad-sugerida)</sup>
+
+En lugar de introducir manualmente URLs y precios, consultar la API de Cardmarket para obtener precios mínimos automáticamente (si la API lo permite).
+
+<a id="item-59"></a>
+
+### 59. Soporte multi-idioma <sup>[↑](#prioridad-sugerida)</sup>
+
+La UI mezcla español e inglés. Implementar un sistema de i18n básico con un objeto de traducciones permitiría soportar ambos idiomas completamente.
+
+<a id="item-60"></a>
+
+### 60. Ordenación de cartas en la tabla <sup>[↑](#prioridad-sugerida)</sup>
+
+Permitir ordenar las filas por: número, estado, precio de compra, precio de Cardmarket, rareza, etc.
+
+<a id="item-61"></a>
+
+### 61. Filtro combinado avanzado <sup>[↑](#prioridad-sugerida)</sup>
+
+Permitir combinar filtros con operadores AND/OR. Por ejemplo: "Cartas que me faltan Y son Super Rare Y del color rojo".
+
+<a id="item-62"></a>
+
+### 62. Resumen de gasto por sesión de edición <sup>[↑](#prioridad-sugerida)</sup>
+
+Al pulsar "Guardar", mostrar un resumen de los cambios realizados: cuántas cartas se marcaron, cuánto se gastó en total en esa sesión.
+
+<a id="item-63"></a>
+
+### 63. Soporte para tokens <sup>[↑](#prioridad-sugerida)</sup>
+
+Algunos sets incluyen tokens (como se indica en los TODOs de `data_2025.js`). Añadir soporte para mostrarlos y trackearlos.
+
+<a id="item-64"></a>
+
+### 64. Caché de imágenes con fallback <sup>[↑](#prioridad-sugerida)</sup>
+
+Si una imagen de carta no carga (404), mostrar un placeholder genérico en lugar de una imagen rota. Actualmente no hay manejo de errores de carga de imágenes.
+
+```js
+img.onerror = () => { img.src = noCardURL; };
+```
+
+<a id="item-65"></a>
+
+### 65. Listado de sleeves <sup>[↑](#prioridad-sugerida)</sup>
+
+Añadir las fundas (sleeves) como producto gestionable dentro de la sección Products, con el mismo sistema de estados y tracking que los sobres.
+
+<a id="item-66"></a>
+
+### 66. Listado de memory gauges <sup>[↑](#prioridad-sugerida)</sup>
+
+Añadir los contadores de memoria (memory gauges) como producto gestionable dentro de la sección Products.
+
+<a id="item-67"></a>
+
+### 67. Listado de cajas <sup>[↑](#prioridad-sugerida)</sup>
+
+Añadir las cajas (booster boxes, starter boxes, etc.) como producto gestionable dentro de la sección Products.
+
+<a id="item-68"></a>
+
+### 68. Filtrar cartas por datos de Cardmarket <sup>[↑](#prioridad-sugerida)</sup>
+
+Nuevos filtros basados en los datos de Cardmarket almacenados:
+
+- Con / sin URL de Cardmarket.
+- Con / sin precio mínimo registrado.
+
+Útil para identificar cartas que aún no se han vinculado a Cardmarket o que no tienen precio actualizado.
+
+<a id="item-69"></a>
+
+### 69. Conteo de imágenes por origen <sup>[↑](#prioridad-sugerida)</sup>
+
+Herramienta o vista que muestre cuántas imágenes de cartas provienen de cada base de URL (bandaitcgplus, digimoncard, fandom, etc.). Útil para mantenimiento y para detectar dependencias de fuentes externas.
+
+<a id="item-70"></a>
+
+### 70. Filtrado por edición de Cardmarket <sup>[↑](#prioridad-sugerida)</sup>
+
+Añadir un nuevo campo en los datos de set para indicar la edición con la que Cardmarket clasifica el producto. Permitiría filtrar cartas según la edición de Cardmarket, facilitando la búsqueda y vinculación de precios.
+
+<a id="item-71"></a>
+
+### 71. Tracking de mazos (fase 1) <sup>[↑](#prioridad-sugerida)</sup>
+
+Permitir registrar mazos como un listado de cartas (identificador + cantidad) para llevar un control de qué cartas están en uso en qué mazo. Esto evita el descontrol entre lo que no se encuentra en el álbum y lo que aparece en los listados. Incluir alguna distinción visual en las cartas que están asignadas a un mazo.
+
+En una segunda fase, esto podría evolucionar hacia un deck builder completo con validación de reglas (máximo 4 copias, 50 cartas, etc.).
+
+<a id="item-72"></a>
+
+### 72. Marcar cartas baneadas, limitadas o con límite de 50 <sup>[↑](#prioridad-sugerida)</sup>
+
+Añadir soporte en los datos de sets para indicar el estado de regulación de cada carta:
+
+- Baneada (no se puede usar en torneo).
+- Limitada (máximo 1 copia en el deck).
+- Límite de 50 (se pueden llevar hasta 50 copias).
+
+Mostrar esta información visualmente en la tabla y/o en el modal de la carta.
+
+<a id="item-73"></a>
+
+### 73. Nuevo color de fondo para playset >4 <sup>[↑](#prioridad-sugerida)</sup>
+
+Actualmente el input de cantidad usa verde (`--four-cards`) para 4 o más copias. Añadir un color diferenciado (azul) cuando la cantidad supera las 4 copias, para distinguir visualmente entre "playset completo" y "exceso de copias".
+
+> **Nota:** El playset se calcula sobre la suma total de copias de todos los bloques. En modo visualización se muestra un único contador con la suma total y un desglose por bloque (tags). En modo edición se muestran los inputs individuales por bloque.
+
+
+
+<a id="item-74"></a>
+
+### 74. Soporte de prefijos de set en el mapa de bloques <sup>[↑](#prioridad-sugerida)</sup>
+
+Cuando `block` es un mapa (bloque → cartas), permitir que los valores del array sean prefijos de set (ej. `"BT1"`, `"BT6"`) además de IDs completos de carta (ej. `"BT1-084"`). Esto simplifica la definición de bloques en sets con `id: null` que mezclan cartas de distintos sets.
+
+Función de resolución acordada (busca primero por ID exacto, luego por prefijo de set):
+
+```js
+function getCardBlock(cardId, block) {
+    if (typeof block === 'number') return block;
+    const setPrefix = cardId.replace(/-\d+$/, '');
+    for (const [b, entries] of Object.entries(block)) {
+        if (entries.includes(cardId) || entries.includes(setPrefix)) return Number(b);
+    }
+    return null;
+}
+```
+
+No separar en dos pasadas (IDs exactos vs prefijos): el coste es insignificante con arrays pequeños y una sola pasada es más legible.
+
+Cuando un set mezcla cartas de distintos bloques y se quiere usar un prefijo general para el bloque mayoritario, colocar el prefijo en el bloque más alto y los IDs específicos en los bloques inferiores. Así los IDs exactos se encuentran antes en la iteración y el prefijo actúa como fallback. El orden inverso (prefijo en bloque bajo) requeriría dos pasadas.
+
+> **Contexto:** Reprint = cualquier reimpresión posterior a la original (incluye alternativas y cambios de bloque). Se mantiene tracking por bloque para posible rotación futura. En la UI, el modo visualización muestra la suma total con desglose por bloque; el modo edición muestra inputs individuales por bloque.
+

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -6,7 +6,7 @@
 |-----------|-------|
 | 🔴 Alta | [1](#item-1), [5](#item-5), [7](#item-7), [19](#item-19), [33](#item-33), [38](#item-38), [64](#item-64) |
 | 🟠 Media | [2](#item-2), [3](#item-3), [4](#item-4), [8](#item-8), [10](#item-10), [12](#item-12), [16](#item-16), [17](#item-17), [18](#item-18), [20](#item-20), [27](#item-27), [29](#item-29), [39](#item-39), [40](#item-40), [68](#item-68), [73](#item-73) |
-| 🟡 Baja | [6](#item-6), [9](#item-9), [11](#item-11), [13](#item-13), [14](#item-14), [15](#item-15), [21](#item-21)–[26](#item-26), [28](#item-28), [30](#item-30)–[32](#item-32), [34](#item-34)–[37](#item-37), [41](#item-41)–[67](#item-67), [69](#item-69)–[72](#item-72), [74](#item-74) |
+| 🟡 Baja | [6](#item-6), [9](#item-9), [11](#item-11), [13](#item-13), [14](#item-14), [15](#item-15), [21](#item-21)–[26](#item-26), [28](#item-28), [30](#item-30)–[32](#item-32), [34](#item-34)–[37](#item-37), [41](#item-41)–[67](#item-67), [69](#item-69)–[72](#item-72), [74](#item-74), [75](#item-75) |
 
 ---
 
@@ -707,4 +707,20 @@ No separar en dos pasadas (IDs exactos vs prefijos): el coste es insignificante 
 Cuando un set mezcla cartas de distintos bloques y se quiere usar un prefijo general para el bloque mayoritario, colocar el prefijo en el bloque más alto y los IDs específicos en los bloques inferiores. Así los IDs exactos se encuentran antes en la iteración y el prefijo actúa como fallback. El orden inverso (prefijo en bloque bajo) requeriría dos pasadas.
 
 > **Contexto:** Reprint = cualquier reimpresión posterior a la original (incluye alternativas y cambios de bloque). Se mantiene tracking por bloque para posible rotación futura. En la UI, el modo visualización muestra la suma total con desglose por bloque; el modo edición muestra inputs individuales por bloque.
+
+<a id="item-75"></a>
+
+### 75. `amount` como mapa por bloque <sup>[↑](#prioridad-sugerida)</sup>
+
+Cambiar la estructura de `collection[setId][cardId].amount` de número a mapa por bloque, eliminando el campo `reprint`. Ver issue [#37](https://github.com/Vegekku/dtcg-web/issues/37).
+
+```js
+// Antes
+{ amount: 4, reprint: { "0": 2, "1": 3 }, cards: { ... } }
+
+// Después
+{ amount: { "0": 4, "1": 2, "2": 3 }, cards: { ... } }
+```
+
+La suma total se calcula en runtime: `Object.values(amount).reduce((a, b) => a + b, 0)`. Cambio MAJOR — requiere migración de datos en localStorage.
 

--- a/UI.md
+++ b/UI.md
@@ -1,0 +1,67 @@
+# Descripción de la interfaz — DTCG Web Collection
+
+Reconstrucción de la UI a partir del código fuente, para referencia futura.
+
+## Layout general (de arriba a abajo)
+
+### 1. Barra de categorías (acordeones)
+
+4-5 botones en fila horizontal: **Boosters (BT)**, **Starters (ST)**, **Extras (EX)**, **Others**, **Products**. Al hacer click en uno se despliega un panel debajo con botones numerados (ej. para Boosters: `1`, `2`, `3`... hasta `23`; para Starters: `7`, `8`... `22`). Solo un acordeón abierto a la vez.
+
+### 2. Botones de edición y descarga (inline)
+
+**Editar** (amarillo), y al activarlo aparecen **Guardar** (verde) y **Cancelar** (rojo). Junto a ellos, **Descargar collection** y **Descargar cardmarket**.
+
+### 3. Barra de filtros
+
+Una línea con:
+- Select **Estado** (Cualquiera, Sin playset ni faltas, Sin playset, Falta, Obtenida, Reservada, Comprada, Proxy)
+- Select **Color primario** (Todos, Rojo, Azul, Amarillo...)
+- Botón `<` | Input de búsqueda de set con datalist | Botón `>`
+- Select **Rareza** (Todos, AA, SP, SEC, SR, P, R, U, C, T)
+
+### 4. Controles de vista
+
+- Select **Listar como**: Tabla / Grid
+- Select **Mostrar**: Colección individual / Todas las colecciones
+
+### 5. Área de contenido principal (scrollable)
+
+**En vista tabla** (por defecto): Una tabla por set con header sticky. Solo se ve el set activo.
+
+| ID + Rareza | Cantidad | Cartas (imágenes) |
+|:-:|:-:|:--|
+| `001` con badge circular de rareza (coloreado según el color de la carta) | **Modo visualización:** Un único contador con la suma total de copias de todos los bloques. Incluye un desglose visual (tipo "tag") que muestra la cantidad por bloque. **Modo edición:** Se muestran inputs individuales por cada bloque para editar la cantidad de cada impresión por separado. El fondo del input varía por cantidad: rojo=0, naranja=1, amarillo=2, verde claro=3, verde=4+. | Fila horizontal de miniaturas (~79×111px). Cada carta tiene un indicador visual de estado: borde lateral verde=obtenida, azul=comprada, teal=proxy, blur=reservada, sin indicador=falta. Si es comprada/proxy sin precio registrado, borde amarillo de revisión. |
+
+**En vista grid**: Se ocultan las columnas de ID y cantidad. Las cartas se muestran como un mosaico inline de miniaturas.
+
+**En "Products > Sobres"**: Las imágenes de los sobres en flex-wrap, con los mismos indicadores de estado por color.
+
+> **Nota sobre productos:** Actualmente solo se muestran sobres, pero la idea original es incluir de forma igualmente clasificada: cajas, fundas, tapetes, contadores de memoria, deckbox y cualquier otro producto relacionado con las cartas.
+
+### 6. Footer
+
+Enlace de donación PayPal | contador de resultados bandai | fecha de última actualización | enlace a GitHub.
+
+### 7. Modal de edición (oculto por defecto, visible en modo edición)
+
+Fondo oscuro semitransparente. Caja blanca centrada con bordes redondeados:
+- Título: `BT15-042: Nombre del set`
+- Imagen de la carta (grande, con border-radius y sombra)
+- 5 radio buttons estilizados como botones con iconos SVG: ❌ Falta | ✅ Obtenida | 🔒 Reservada | 💶 Comprada | 🖨️ Proxy
+- Campo de precio (aparece al seleccionar Comprada/Proxy)
+- Sección Cardmarket: icono + input URL + input precio mínimo
+- Botón azul grande "confirmar"
+- Botón X rojo arriba a la derecha
+
+### 8. Modal de visualización (modo no edición)
+
+Similar pero sin radio buttons ni inputs editables. Muestra:
+- Imagen de la carta (más grande)
+- Estado en texto + precio si aplica
+- Cantidad total de copias (suma de todos los bloques) con desglose por bloque
+- Enlace a Cardmarket con precio mínimo
+
+### Impresión
+
+Al imprimir se oculta todo lo que tiene clase `no-print` (filtros, botones, footer) y el contenido se expande sin scroll, con colores exactos preservados.

--- a/UI_REDESIGN.md
+++ b/UI_REDESIGN.md
@@ -1,0 +1,371 @@
+# Propuestas de rediseño UI — DTCG Web Collection
+
+Propuestas ordenadas de menor a mayor esfuerzo. Cada nivel se puede implementar de forma independiente.
+
+## Prioridad sugerida
+
+| Prioridad | Propuestas | Motivo |
+|-----------|-----------|--------|
+| 🔴 Alta | [2.1](#prop-21), [2.2](#prop-22), [2.3](#prop-23), [2.7](#prop-27), [2.8](#prop-28) | Resuelven directamente los pain points: búsqueda flexible, filtros combinables, edición multi-set, cantidad compacta en visualización, filtro sin playset real |
+| 🟠 Media | [1.1](#prop-11)–[1.5](#prop-15), [2.4](#prop-24), [2.6](#prop-26), [3.2](#prop-32), [3.3](#prop-33), [3.6](#prop-36) | Mejoran la percepción visual, velocidad de edición y cantidad en grid |
+| 🟡 Baja | [2.5](#prop-25), [3.1](#prop-31), [3.4](#prop-34)–[3.5](#prop-35), [4.x](#nivel-4-redise%C3%B1o-de-layout-completo) | Mejoras de calidad de vida y rediseño mayor, para cuando las prioridades altas estén resueltas |
+
+---
+
+## Índice
+
+- [Nivel 1: Ajustes rápidos (CSS + HTML mínimo)](#nivel-1-ajustes-rápidos)
+- [Nivel 2: Mejoras funcionales (JS moderado)](#nivel-2-mejoras-funcionales)
+- [Nivel 3: Rediseño parcial de componentes](#nivel-3-rediseño-parcial-de-componentes)
+- [Nivel 4: Rediseño de layout completo](#nivel-4-rediseño-de-layout-completo)
+
+---
+
+## Nivel 1: Ajustes rápidos
+
+Cambios cosméticos que mejoran la percepción visual sin tocar la estructura.
+
+<a id="prop-11"></a>
+
+### 1.1 Tipografía y espaciado <sup>[↑](#prioridad-sugerida)</sup>
+
+La fuente actual (Arial/Helvetica) y la falta de espaciado entre secciones contribuyen al aspecto "tosco". Cambios mínimos:
+
+- Usar una fuente con más personalidad pero igual de legible: `Inter`, `Nunito` o `Rubik` (Google Fonts, una línea de import).
+- Añadir `gap`/`margin` consistente entre la barra de acordeones, los filtros y el contenido.
+- Aumentar ligeramente el `padding` de los botones de set y los filtros.
+
+<a id="prop-12"></a>
+
+### 1.2 Suavizar bordes y sombras <sup>[↑](#prioridad-sugerida)</sup>
+
+- Los bordes de la tabla son `1px solid black`. Cambiar a un gris suave (`#e0e0e0`) y añadir `border-radius` sutil a la tabla.
+- Añadir una sombra ligera (`box-shadow`) al contenedor de contenido para dar profundidad.
+- Los botones de acordeón no tienen fondo visible en estado inactivo. Darles un fondo sutil (`#f5f5f5`) para que se perciban como elementos interactivos.
+
+<a id="prop-13"></a>
+
+### 1.3 Paleta de colores más cohesiva <sup>[↑](#prioridad-sugerida)</sup>
+
+Los colores de estado (verde, azul, teal, amarillo, rojo) están bien elegidos pero el resto de la UI no tiene una paleta definida. Definir:
+
+- Un color primario para acciones principales (ya usas `--blue-card` en el botón confirmar).
+- Un gris neutro para fondos y bordes.
+- Reducir el contraste del footer (actualmente texto negro sobre blanco, se puede suavizar).
+
+<a id="prop-14"></a>
+
+### 1.4 Mejorar los botones de set <sup>[↑](#prioridad-sugerida)</sup>
+
+Actualmente son botones planos sin mucha identidad. Mejoras rápidas:
+
+- Fondo con el color predominante del set (o un gradiente sutil).
+- Indicar visualmente cuál está activo (no solo con la clase CSS, sino con un estilo más marcado: borde inferior, fondo más oscuro).
+- Tooltip más informativo: además del nombre, mostrar "BT21 — 45/102" (progreso).
+
+<a id="prop-15"></a>
+
+### 1.5 Hover y transiciones en las cartas <sup>[↑](#prioridad-sugerida)</sup>
+
+Las miniaturas de cartas no tienen feedback visual al pasar el ratón. Añadir:
+
+- `transform: scale(1.05)` con `transition` al hacer hover.
+- `cursor: pointer` (ya lo tiene) + un ligero `box-shadow` al hover.
+
+---
+
+## Nivel 2: Mejoras funcionales
+
+Cambios que mejoran la usabilidad basándose en los pain points descritos.
+
+<a id="prop-21"></a>
+
+### 2.1 Búsqueda de set flexible (fuzzy search) <sup>[↑](#prioridad-sugerida)</sup>
+
+El buscador actual requiere coincidencia exacta con el datalist. Reemplazar por una búsqueda que:
+
+- Filtre mientras se escribe (no solo al seleccionar del datalist).
+- Busque en el nombre completo del set, no solo en el valor exacto del option.
+- Permita búsquedas parciales: escribir "reprint" mostraría todos los sets cuyo nombre contenga "reprint".
+- Mostrar los resultados como un dropdown custom en lugar del datalist nativo (que es limitado y feo).
+
+<a id="prop-22"></a>
+
+### 2.2 Filtros combinables (multi-select) <sup>[↑](#prioridad-sugerida)</sup>
+
+El filtro de estado actual es un select simple. Reemplazar por un sistema que permita selección múltiple:
+
+- Seleccionar múltiples estados a la vez: "Reservada + Comprada".
+- Seleccionar múltiples rarezas: "SR + SEC".
+
+**Decisión tomada:** Reemplazar los `<select>` actuales por checkboxes. Permite selección múltiple de forma visual y directa, sin interacciones extra. Ocupa más espacio horizontal, pero encaja bien si se combina con el panel de filtros colapsable (propuesta 3.4).
+
+Opciones descartadas:
+- **Select con checkboxes dentro** (dropdown) — Más compacto pero requiere JS adicional y oculta las opciones activas.
+- **Multi-select nativo** (`<select multiple>`) — UX pobre (Ctrl+click), inconsistente entre navegadores.
+
+<a id="prop-23"></a>
+
+### 2.3 Edición multi-set sin cambiar de vista <sup>[↑](#prioridad-sugerida)</sup>
+
+Cuando compras cartas de varios sets, actualmente tienes que navegar entre sets uno a uno. Opciones:
+
+- **Barra de búsqueda rápida de carta**: Un input donde escribes "BT21-029" y te abre directamente el modal de esa carta, sin necesidad de navegar al set.
+- **Modo "edición rápida"**: Al activar edición, mostrar un input de búsqueda prominente arriba que permita saltar entre cartas de cualquier set.
+
+<a id="prop-24"></a>
+
+### 2.4 Contador de resultados en filtros <sup>[↑](#prioridad-sugerida)</sup>
+
+Cuando aplicas filtros, no sabes cuántas cartas coinciden. Mostrar un contador:
+
+```
+Filtros: Estado[Comprada] Color[Rojo] → 23 cartas encontradas
+```
+
+Relacionado: ocultar automáticamente las tablas de sets que no tengan resultados tras aplicar filtros, para no mostrar tablas vacías.
+
+<a id="prop-25"></a>
+
+### 2.5 Persistir filtros y vista en la URL <sup>[↑](#prioridad-sugerida)</sup>
+
+Actualmente solo el set activo se guarda en el hash de la URL. Guardar también los filtros activos y el tipo de vista como query params:
+
+```
+#BT21?status=bought_it&color=red&view=grid
+```
+
+Esto permite compartir enlaces con filtros aplicados y que al recargar la página se mantengan.
+
+<a id="prop-26"></a>
+
+### 2.6 Mejorar el flujo de edición de cantidad <sup>[↑](#prioridad-sugerida)</sup>
+
+Los inputs de cantidad requieren hacer click, escribir y salir del campo. Para edición rápida de varias cartas seguidas, añadir botones `+` / `-` a los lados del input (visibles solo en modo edición):
+
+```
+[-] [ 3 ] [+]
+```
+
+<a id="prop-27"></a>
+
+### 2.7 Columna de cantidad compacta en modo visualización <sup>[↑](#prioridad-sugerida)</sup>
+
+El problema: la columna `card_amount` tiene un ancho uniforme para todas las filas (comportamiento de `<table>`). Las filas con inputs de reprint ensanchan la columna, dejando un hueco en las filas que solo tienen el input principal.
+
+El flujo de edición actual (inputs directamente editables sin modal ni despliegue extra) es bueno y no debe cambiar. El problema es solo en modo visualización, donde los inputs ocupan demasiado espacio para mostrar un número del 0 al 4.
+
+Propuesta principal: **en modo visualización, reemplazar todos los inputs (principal + reprints) por una representación compacta**. Al activar edición, se muestran los inputs reales.
+
+**Decisión tomada:** En modo visualización se muestra un único contador con la **suma total** de copias de todos los bloques, acompañado de un desglose por bloque a modo de "tags" dentro del contador. En modo edición se muestran los inputs individuales por bloque.
+
+Esto combina las opciones A y D: el número principal es la suma total (como D), pero el desglose por bloque es visible de un vistazo sin interacción (como A), usando tags compactos.
+
+```
+┌─────────────┐
+│ 4           │  ← carta sin reprints: solo el total
+└─────────────┘
+
+┌─────────────────────────┐
+│ 6  [●4] [●2]           │  ← carta con reprints: total + tags por bloque
+└─────────────────────────┘
+```
+
+> **Nota:** El diseño exacto de los tags (icono de bloque, color, forma) está pendiente de definir. La idea es que sean lo suficientemente compactos para no ensanchar la columna pero informativos de un vistazo.
+
+<a id="prop-28"></a>
+
+### 2.8 Filtro "Sin playset" basado en inputs <sup>[↑](#prioridad-sugerida)</sup>
+
+El filtro actual (`no_pull`) oculta filas donde `data-pull="true"` (cantidad principal ≥ 4). Esto solo evalúa el input de cantidad global de la carta, sin tener en cuenta los inputs individuales de cada variante (original, reprints por bloque).
+
+Comportamiento deseado: mostrar la fila completa (todos los inputs + todas las imágenes) siempre que **al menos un input** de esa carta no tenga playset. El filtro opera a nivel de fila, no de input individual.
+
+> **Nota:** Dado que en modo visualización se muestra la suma total de todos los bloques, el filtro "sin playset" debe evaluar cada bloque individualmente (no la suma). Una carta con 6 copias totales (4 del bloque original + 2 de un reprint) no tiene playset en el bloque de reprint, por lo que debe mostrarse.
+
+Esto implica:
+
+- Evaluar el input principal (`amount-card`) y los inputs de reprint (`amount-card--reprint`) de cada fila.
+- Si todos los inputs de la fila tienen valor ≥ 4, la fila se oculta.
+- Si al menos uno tiene valor < 4, la fila se muestra entera.
+
+Evolución futura (por fases):
+
+1. **Filtrar por playset específico**: Permitir seleccionar qué tipo de playset evaluar (original, reprint bloque N, etc.).
+2. **Mostrar solo inputs sin playset**: Dentro de una fila visible, resaltar u ocultar los inputs que ya tienen playset, mostrando solo los que faltan.
+3. **Filtrar imágenes por bloque**: Mostrar solo las imágenes de las cartas que pertenezcan al input sin playset, usando el bloque (original vs reprint) para vincular cada imagen con su input correspondiente.
+
+---
+
+## Nivel 3: Rediseño parcial de componentes
+
+Rediseño visual de partes específicas de la UI manteniendo la estructura general.
+
+<a id="prop-31"></a>
+
+### 3.1 Rediseño de la barra de navegación <sup>[↑](#prioridad-sugerida)</sup>
+
+Reemplazar los acordeones por una barra de navegación con tabs:
+
+```
+┌─────────┬──────────┬────────┬────────┬──────────┐
+│Boosters │ Starters │ Extras │ Others │ Products │
+└─────────┴──────────┴────────┴────────┴──────────┘
+  1  2  3  4  5  6  7  8  9  10 ... 21  22  23
+```
+
+- Los tabs de categoría siempre visibles (no acordeón que colapsa).
+- Los botones de set en scroll horizontal debajo del tab activo.
+- El tab activo con un indicador visual claro (borde inferior coloreado).
+
+<a id="prop-32"></a>
+
+### 3.2 Rediseño del modal de edición <sup>[↑](#prioridad-sugerida)</sup>
+
+El modal actual funciona pero se puede mejorar:
+
+- **Navegación entre cartas dentro del modal**: Flechas izquierda/derecha (o swipe) para ir a la carta anterior/siguiente sin cerrar el modal. Esto acelera mucho la edición de varias cartas seguidas.
+- **Preview del estado actual**: Mostrar el estado actual de la carta antes de editarlo (actualmente hay que mirar qué radio está seleccionado).
+- **Historial de precios visible**: Si hay historial de Cardmarket, mostrar los últimos 3-5 precios como sparkline o lista.
+- **Atajos de teclado**: `1-5` para seleccionar estado, `Enter` para confirmar, `Escape` para cerrar, `←`/`→` para navegar.
+
+<a id="prop-33"></a>
+
+### 3.3 Rediseño de la vista grid <sup>[↑](#prioridad-sugerida)</sup>
+
+La vista grid actual simplemente oculta columnas de la tabla. Rediseñarla como un grid CSS real:
+
+- Cartas más grandes que en la vista tabla.
+- Badge de estado superpuesto en la esquina (icono pequeño: ✓, €, 🖨, 🔒).
+- Badge de cantidad superpuesto en la otra esquina (resuelve el problema de no ver la cantidad al filtrar por "Sin playset" en grid).
+- Agrupación visual por rareza o color (separadores).
+
+<a id="prop-36"></a>
+
+### 3.6 Vista álbum <sup>[↑](#prioridad-sugerida)</sup>
+
+Nueva vista que muestra las cartas en formato álbum de colección:
+
+- Layout 3×3 (9 cartas por página) o 3×4 (12 cartas por página), configurable.
+- Cartas a tamaño mayor que en tabla/grid.
+- Pensada para visualización y consulta, no para edición.
+- Ideal para impresión.
+
+<a id="prop-34"></a>
+
+### 3.4 Panel de filtros colapsable <sup>[↑](#prioridad-sugerida)</sup>
+
+En lugar de una línea de filtros siempre visible, un panel que se despliega:
+
+- Botón "Filtros" con badge indicando cuántos filtros activos.
+- Al expandir, muestra todos los filtros con más espacio.
+- Permite añadir los filtros combinables (nivel 2.2) sin saturar la cabecera.
+- En móvil, se abre como panel lateral (drawer).
+
+<a id="prop-35"></a>
+
+### 3.5 Barra de acciones contextual <sup>[↑](#prioridad-sugerida)</sup>
+
+Cuando estás en modo edición, reemplazar la barra actual (Editar/Guardar/Cancelar) por una barra fija en la parte inferior de la pantalla (sticky bottom bar):
+
+```
+┌──────────────────────────────────────────────────┐
+│  Editando BT21  │  3 cambios  │ [Cancelar] [Guardar] │
+└──────────────────────────────────────────────────┘
+```
+
+- Muestra qué set estás editando.
+- Contador de cambios realizados.
+- Siempre visible aunque hagas scroll.
+
+---
+
+## Nivel 4: Rediseño de layout completo
+
+Repensar la estructura de la página desde cero.
+
+<a id="prop-41"></a>
+
+### 4.1 Layout con sidebar <sup>[↑](#prioridad-sugerida)</sup>
+
+Reemplazar los acordeones + botones por un sidebar lateral fijo:
+
+```
+┌──────────┬───────────────────────────────────────────┐
+│          │  Filtros + controles                      │
+│ Boosters │  ─────────────────────────────────────    │
+│  BT1     │                                           │
+│  BT2     │  ┌─────┬─────┬──────────────────────┐    │
+│  ...     │  │ ID  │ Qty │ Cards                │    │
+│  BT23    │  ├─────┼─────┼──────────────────────┤    │
+│          │  │ 001 │ [4] │ [img][img][img]      │    │
+│ Starters │  │ 002 │ [0] │ [img][img]           │    │
+│  ST7     │  │ ... │     │                      │    │
+│  ...     │  └─────┴─────┴──────────────────────┘    │
+│          │                                           │
+│ Extras   │  footer                                   │
+│ Others   │                                           │
+│ Products │                                           │
+└──────────┴───────────────────────────────────────────┘
+```
+
+- Sidebar colapsable en móvil (hamburger menu).
+- Categorías como secciones expandibles dentro del sidebar.
+- El set activo resaltado en el sidebar.
+- Más espacio horizontal para la tabla de cartas.
+
+<a id="prop-42"></a>
+
+### 4.2 Dashboard con resumen <sup>[↑](#prioridad-sugerida)</sup>
+
+Añadir una vista "Home" que se muestre al abrir la app (antes de seleccionar un set):
+
+- Resumen general: total de cartas, porcentaje de completitud, gasto total.
+- Top 5 sets más completos / menos completos.
+- Últimas cartas editadas.
+- Acceso rápido a los sets recientes.
+- Gráfico simple de distribución por estado (barras CSS, sin librería).
+
+<a id="prop-43"></a>
+
+### 4.3 Vista de carta expandida <sup>[↑](#prioridad-sugerida)</sup>
+
+Al hacer click en una carta (en modo no edición), en lugar de un modal, expandir la fila de la tabla para mostrar la información inline:
+
+```
+├─────┼─────┼──────────────────────────────────────┤
+│ 029 │ [2] │ [img][img][img]                      │
+│(sr) │     │                                      │
+│     │     │ ┌──────────────────────────────────┐ │
+│     │     │ │  [imagen grande]                 │ │
+│     │     │ │  Obtenida | Cardmarket: 3,20€    │ │
+│     │     │ └──────────────────────────────────┘ │
+├─────┼─────┼──────────────────────────────────────┤
+```
+
+Esto evita el cambio de contexto del modal para consultas rápidas.
+
+<a id="prop-44"></a>
+
+### 4.4 Modo "lista de compra" <sup>[↑](#prioridad-sugerida)</sup>
+
+Una vista dedicada que muestra solo las cartas con estado "Reservada" o "Falta" que el usuario quiere comprar:
+
+- Agrupadas por set o por vendedor (si se añade ese dato).
+- Con precio de Cardmarket y enlace directo.
+- Total estimado de la compra.
+- Checkbox para marcar como comprada directamente desde esta vista.
+
+<a id="prop-45"></a>
+
+### 4.5 Tema visual completo <sup>[↑](#prioridad-sugerida)</sup>
+
+Definir un sistema de diseño mínimo pero cohesivo:
+
+- Paleta de 5-6 colores (primario, secundario, éxito, peligro, neutros).
+- Escala tipográfica (3-4 tamaños con jerarquía clara).
+- Espaciado consistente (múltiplos de 4px u 8px).
+- Componentes reutilizables: botón, input, select, badge, card, modal.
+- Dark mode como variante de la misma paleta.
+
+

--- a/css/style.css
+++ b/css/style.css
@@ -204,6 +204,10 @@ tr:not([data-color]) .card_info__rarity, tr[data-color=undefined] .card_info__ra
   text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
   color: white;
 }
+[data-color=green-white] .card_info {
+  background: linear-gradient(90deg, var(--green-card) 50%, var(--white-card) 50%);
+  text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
+}
 [data-color=black] .card_info {
   background-color: var(--black-card);
 }
@@ -240,6 +244,9 @@ tr:not([data-color]) .card_info__rarity, tr[data-color=undefined] .card_info__ra
 }
 [data-color=purple-red] .card_info {
   background: linear-gradient(90deg, var(--purple-card) 50%, var(--red-card) 50%);
+}
+[data-color=purple-red-green] .card_info {
+  background: repeating-linear-gradient(to right, var(--purple-card), var(--purple-card) 33.33%, var(--red-card) 33.33%, var(--red-card) 66.66%, var(--green-card) 66.66%, var(--green-card));
 }
 [data-color=purple-blue] .card_info {
   background: linear-gradient(90deg, var(--purple-card) 50%, var(--blue-card) 50%);
@@ -589,6 +596,16 @@ tr:not([data-color]) .card_info__rarity, tr[data-color=undefined] .card_info__ra
   background-clip: text;
   color: transparent;
 }
+[data-color=green-white] .card_info__rarity {
+  background: linear-gradient(90deg, var(--white-card) 0%, var(--white-card) 50.5%, var(--black-card) 49.5%, var(--black-card) 100%);
+}
+[data-color=green-white] .card_info__rarity span {
+  background: linear-gradient(90deg, var(--green-card) 0%, var(--green-card) 50.5%, var(--white-card) 49.5%, var(--white-card) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  color: transparent;
+}
 [data-color=black] .card_info__rarity {
   background: var(--white-card);
 }
@@ -664,6 +681,16 @@ tr:not([data-color]) .card_info__rarity, tr[data-color=undefined] .card_info__ra
 }
 [data-color=purple-red] .card_info__rarity span {
   background: linear-gradient(90deg, var(--purple-card) 0%, var(--purple-card) 50.5%, var(--red-card) 49.5%, var(--red-card) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  color: transparent;
+}
+[data-color=purple-red-green] .card_info__rarity {
+  background: var(--white-card);
+}
+[data-color=purple-red-green] .card_info__rarity span {
+  background: linear-gradient(90deg, var(--purple-card) 0%, var(--purple-card) 33.8333333333%, var(--red-card) 32.8333333333%, var(--red-card) 67.1666666667%, var(--green-card) 66.1666666667%, var(--green-card) 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;

--- a/css/style.css
+++ b/css/style.css
@@ -934,6 +934,34 @@ button.accordion.active:after {
   display: none;
 }
 
+.filter--block tbody tr:not(.match_filter--block) {
+  display: none;
+}
+.filter--block .card:not(.filtered--block) {
+  display: none;
+}
+.filter--block.block--0 .amount-card:not([data-block="0"]) {
+  display: none;
+}
+.filter--block.block--1 .amount-card:not([data-block="1"]) {
+  display: none;
+}
+.filter--block.block--2 .amount-card:not([data-block="2"]) {
+  display: none;
+}
+.filter--block.block--3 .amount-card:not([data-block="3"]) {
+  display: none;
+}
+.filter--block.block--4 .amount-card:not([data-block="4"]) {
+  display: none;
+}
+.filter--block.block--5 .amount-card:not([data-block="5"]) {
+  display: none;
+}
+.filter--block.block--6 .amount-card:not([data-block="6"]) {
+  display: none;
+}
+
 .filter--color tbody tr:not(.filtered--color) {
   display: none;
 }

--- a/index.html
+++ b/index.html
@@ -81,6 +81,7 @@
                 <option value="aa">Alternative Art</option>
                 <option value="sp">Special</option>
                 <option value="sec">Secret Rare</option>
+                <option value="ur">Ultimate Rare</option>
                 <option value="sr">Super Rare</option>
                 <option value="p">Promo</option>
                 <option value="r">Rare</option>
@@ -109,7 +110,7 @@
             </div>
         </div>
     </div>
-    <a href="https://paypal.me/vegekku/1.5" class="no-print" target="_blank">Un pañal para Ennis :)</a> | <span class="no-print">bandai: 5926 results</span> | <span class="no-print">Last update: Dec. 5, 2025</span> | <a href="https://github.com/Vegekku/dtcg-web" class="no-print" target="_blank">GitHub</a>
+    <a href="https://paypal.me/vegekku/1.5" class="no-print" target="_blank">Un pañal para Ennis :)</a> | <span class="no-print">bandai: 5926 results</span> | <span class="no-print">Last update: May 22, 2026</span> | <a href="https://github.com/Vegekku/dtcg-web" class="no-print" target="_blank">GitHub</a>
     
     <div class="modal" id="editModal">
         <div class="modal-bg modal-exit" onclick="modalClose(this)"></div>

--- a/index.html
+++ b/index.html
@@ -89,6 +89,18 @@
                 <option value="c">Common</option>
                 <option value="t">Token</option>
             </select>
+
+            <label for="block">Bloque</label>
+            <select name="block" id="block" onchange="filterCards()">
+                <option value="">Todos</option>
+                <option value="0">Bloque 0</option>
+                <option value="1">Bloque 1</option>
+                <option value="2">Bloque 2</option>
+                <option value="3">Bloque 3</option>
+                <option value="4">Bloque 4</option>
+                <option value="5">Bloque 5</option>
+                <option value="6">Bloque 6</option>
+            </select>
         </div>
         <div class="views">
             <label for="list">Listar como</label>

--- a/js/data/data_2021.js
+++ b/js/data/data_2021.js
@@ -1092,7 +1092,7 @@ const data2021 = [
     // June Premier TO events --- premierto
     {
         "id": null,
-        "block": 1,
+        "block": 0, // las cartas tiene bloque 1, pero al ser premios lo consideramos por su bloque original 0
         "slug": "premierto",
         "name": "June Premier TO events",
         "release": "June 2021",

--- a/js/data/data_2021.js
+++ b/js/data/data_2021.js
@@ -3,6 +3,7 @@ const data2021 = [
     // Starter Deck GAIA RED [ST-1] --- st1
     {
         "id": "ST1",
+        "block": 0,
         "slug": "st1", 
         "name": "Starter Deck GAIA RED [ST-1]",
         "release": "January 29th, 2021",
@@ -21,6 +22,7 @@ const data2021 = [
     // Starter Deck COCYTUS BLUE [ST-2] --- st2
     {
         "id": "ST2",
+        "block": 0,
         "slug": "st2", 
         "name": "Starter Deck COCYTUS BLUE [ST-2]",
         "release": "January 29th, 2021",
@@ -39,6 +41,7 @@ const data2021 = [
     // Starter Deck HEAVEN'S YELLOW [ST-3] --- st3
     {
         "id": "ST3",
+        "block": 0,
         "slug": "st3", 
         "name": "Starter Deck HEAVEN'S YELLOW [ST-3]",
         "release": "January 29th, 2021",
@@ -57,6 +60,7 @@ const data2021 = [
     // Tamer Party Vol.1 --- tp1
     {
         "id": null,
+        "block": 0,
         "slug": "tp1", 
         "name": "Tamer Party Vol.1",
         "release": "January 29th, 2021",
@@ -73,6 +77,7 @@ const data2021 = [
     // Release Special Booster Ver.1.0 [BT01-03] --- sbt10
     {
         "id": null,
+        "block": 0,
         "slug": "sbt10",
         "name": "Release Special Booster Ver.1.0 [BT01-03]",
         "release": "February 12, 2021",
@@ -300,6 +305,7 @@ const data2021 = [
     // Release Special Booster Ver.1.0 [BT01-03] - Alternatives --- sbt10_alts
     {
         "id": null,
+        "block": 0,
         "slug": "sbt10_alts",
         "name": "Release Special Booster Ver.1.0 [BT01-03] - Alternatives",
         "release": "February 12, 2021",
@@ -327,6 +333,7 @@ const data2021 = [
     // Release Special Booster Ver.1.0 [BT01-03] - Box Topper --- sbt10_boxtopper
     {
         "id": null,
+        "block": 0,
         "slug": "sbt10_boxtopper",
         "name": "Release Special Booster Ver.1.0 [BT01-03] - Box Topper",
         "release": "February 12, 2021",
@@ -347,6 +354,7 @@ const data2021 = [
     // Special Box Promotion Pack --- sbp
     {
         "id": null,
+        "block": 0,
         "slug": "sbp",
         "name": "Special Box Promotion Pack",
         "release": "February 12, 2021",
@@ -365,6 +373,7 @@ const data2021 = [
     // Dash Pack Ver. 1.0 --- dp10
     {
         "id": null,
+        "block": 0,
         "slug": "dp10",
         "name": "Dash Pack Ver. 1.0",
         "release": "February 12, 2021",
@@ -383,6 +392,7 @@ const data2021 = [
     // Tamer's Evolution Box [PB-01] --- pb01
     {
         "id": null,
+        "block": 0,
         "slug": "pb01",
         "name": "Tamer's Evolution Box [PB-01]",
         "release": "February, 2021",
@@ -403,6 +413,7 @@ const data2021 = [
     // Official Tournament Pack Vol.1 --- otp1
     {
         "id": null,
+        "block": 0,
         "slug": "otp1",
         "name": "Official Tournament Pack Vol.1",
         "release": "February, 2021",
@@ -423,6 +434,7 @@ const data2021 = [
     // Tamer Battle Pack 1 --- tbp1
     {
         "id": null,
+        "block": 0,
         "slug": "tbp1",
         "name": "Tamer Battle Pack 1",
         "release": "February, 2021",
@@ -440,6 +452,7 @@ const data2021 = [
     // Promotion Pack Ver.0.0 --- pp0
     {
         "id": null,
+        "block": 0,
         "slug": "pp0",
         "name": "Promotion Pack Ver.0.0",
         "release": "March 2021",
@@ -461,6 +474,7 @@ const data2021 = [
     // Release Special Booster Ver.1.5 [BT01-03] --- sbt15
     {
         "id": null,
+        "block": 0,
         "slug": "sbt15",
         "name": "Release Special Booster Ver.1.5 [BT01-03]",
         "release": "March 12, 2021",
@@ -652,6 +666,7 @@ const data2021 = [
     // Release Special Booster Ver.1.5 [BT01-03] - Alternatives --- sbt15_alts
     {
         "id": null,
+        "block": 0,
         "slug": "sbt15_alts",
         "name": "Release Special Booster Ver.1.5 [BT01-03] - Alternatives",
         "release": "March 12, 2021",
@@ -673,6 +688,7 @@ const data2021 = [
     // Release Special Booster Ver.1.5 [BT01-03] - Box Topper --- sbt15_boxtopper
     {
         "id": null,
+        "block": 0,
         "slug": "sbt15_boxtopper",
         "name": "Release Special Booster Ver.1.5 [BT01-03] - Box Topper",
         "release": "March 12, 2021",
@@ -689,6 +705,7 @@ const data2021 = [
     // Dash Pack Ver. 1.5 --- dp15
     {
         "id": null,
+        "block": 0,
         "slug": "dp15",
         "name": "Dash Pack Ver. 1.5",
         "release": "March 12, 2021",
@@ -705,6 +722,7 @@ const data2021 = [
     // Special Release Memorial Pack! --- srmp
     {
         "id": null,
+        "block": 0,
         "slug": "srmp",
         "name": "Special Release Memorial Pack!",
         "release": "March 12, 2021",
@@ -723,6 +741,7 @@ const data2021 = [
     // Premium Pack Set 01 [PP01] --- pp01
     {
         "id": null,
+        "block": 0,
         "slug": "pp01",
         "name": "Premium Pack Set 01 [PP01]",
         "release": "May 28th, 2021",
@@ -737,6 +756,7 @@ const data2021 = [
     // Great Legend (BT-04) Pre-Release Tournaments --- bt4_prerelease
     {
         "id": null,
+        "block": 0,
         "slug": "bt4_prerelease",
         "name": "Great Legend (BT-04) Pre-Release Tournaments",
         "release": "June 4-10, 2021",
@@ -756,6 +776,7 @@ const data2021 = [
     // Starter Deck GIGA GREEN [ST-4] --- st4
     {
         "id": "ST4",
+        "block": 0,
         "slug": "st4",
         "name": "Starter Deck GIGA GREEN [ST-4]",
         "release": "June 11, 2021",
@@ -774,6 +795,7 @@ const data2021 = [
     // Starter Deck MACHINE BLACK [ST-5] --- st5
     {
         "id": "ST5",
+        "block": 0,
         "slug": "st5",
         "name": "Starter Deck MACHINE BLACK [ST-5]",
         "release": "June 11, 2021",
@@ -792,6 +814,7 @@ const data2021 = [
     // Starter Deck VENOMOUS VIOLET [ST-6] --- st6
     {
         "id": "ST6",
+        "block": 0,
         "slug": "st6",
         "name": "Starter Deck VENOMOUS VIOLET [ST-6]",
         "release": "June 11, 2021",
@@ -811,6 +834,7 @@ const data2021 = [
     // Booster Great Legend [BT4] --- bt4
     {
         "id": "BT4",
+        "block": 0,
         "slug": "bt4",
         "name": "Booster Great Legend [BT4]",
         "release": "June 11, 2021",
@@ -839,6 +863,7 @@ const data2021 = [
     // Booster Great Legend [BT4] - Alternatives --- bt4_alts
     {
         "id": null,
+        "block": 0,
         "slug": "bt4_alts",
         "name": "Booster Great Legend [BT4] - Alternatives",
         "release": "June 11, 2021",
@@ -864,6 +889,7 @@ const data2021 = [
     // Booster Great Legend [BT4] - Box Topper --- bt4_boxtopper
     {
         "id": null,
+        "block": 0,
         "slug": "bt4_boxtopper",
         "name": "Booster Great Legend [BT4] - Box Topper",
         "release": "June 11, 2021",
@@ -880,6 +906,7 @@ const data2021 = [
     // Great Dash Pack --- bt4_dash
     {
         "id": null,
+        "block": 0,
         "slug": "bt4_dash",
         "name": "Great Dash Pack",
         "release": "June 11, 2021",
@@ -895,6 +922,7 @@ const data2021 = [
     // Great Legend Power Up Pack --- bt4_powerup
     {
         "id": null,
+        "block": 0,
         "slug": "bt4_powerup",
         "name": "Great Legend Power Up Pack",
         "release": "June 11, 2021",
@@ -913,6 +941,7 @@ const data2021 = [
     // Great Legend Power Up Pack (Foil) --- bt4_powerup_foil
     {
         "id": null,
+        "block": 0,
         "slug": "bt4_powerup_foil",
         "name": "Great Legend Power Up Pack (Foil)",
         "release": "June 11, 2021",
@@ -931,6 +960,7 @@ const data2021 = [
     // Tamer Party Vol.2 --- tp2
     {
         "id": null,
+        "block": 0,
         "slug": "tp2",
         "name": "Tamer Party Vol.2",
         "release": "June 2021",
@@ -945,6 +975,7 @@ const data2021 = [
     // Official Tournament Pack Vol.2 --- otp2
     {
         "id": null,
+        "block": 0,
         "slug": "otp2",
         "name": "Official Tournament Pack Vol.2",
         "release": "June, 2021",
@@ -964,6 +995,7 @@ const data2021 = [
     // Battle of Omni (BT-05) Pre-Release Tournaments --- bt5_prerelease
     {
         "id": null,
+        "block": 0,
         "slug": "bt5_prerelease",
         "name": "Battle of Omni (BT-05) Pre-Release Tournaments",
         "release": "July 30-August 5, 2021",
@@ -980,6 +1012,7 @@ const data2021 = [
     // July Evolution Cup --- evocup
     {
         "id": null,
+        "block": 0,
         "slug": "evocup",
         "name": "July Evolution Cup",
         "release": "July 2021",
@@ -995,6 +1028,7 @@ const data2021 = [
     // Booster Battle of Omni [BT5] --- bt5
     {
         "id": "BT5",
+        "block": 0,
         "slug": "bt5",
         "name": "Booster Battle of Omni [BT5]",
         "release": "August 6, 2021",
@@ -1023,6 +1057,7 @@ const data2021 = [
     // Booster Battle of Omni [BT5] - Alternatives --- bt5_alts
     {
         "id": null,
+        "block": 0,
         "slug": "bt5_alts",
         "name": "Booster Battle of Omni [BT5] - Alternatives",
         "release": "August 6, 2021",
@@ -1040,6 +1075,7 @@ const data2021 = [
     // Booster Battle of Omni [BT5] - Box Topper --- bt5_boxtopper
     {
         "id": null,
+        "block": 0,
         "slug": "bt5_boxtopper",
         "name": "Booster Battle of Omni [BT5] - Box Topper",
         "release": "August 6, 2021",
@@ -1056,6 +1092,7 @@ const data2021 = [
     // June Premier TO events --- premierto
     {
         "id": null,
+        "block": 1,
         "slug": "premierto",
         "name": "June Premier TO events",
         "release": "June 2021",
@@ -1070,6 +1107,7 @@ const data2021 = [
     // Event Pack 1 --- eventpack1
     {
         "id": null,
+        "block": 0,
         "slug": "eventpack1",
         "name": "Event Pack 1",
         "release": "July 2021",
@@ -1101,6 +1139,7 @@ const data2021 = [
     // 2021 Online Regionals Participant Set --- regional2021_0
     {
         "id": null,
+        "block": 0,
         "slug": "regional2021_0",
         "name": "2021 Online Regionals Participant Set",
         "release": "August 2021",
@@ -1119,6 +1158,7 @@ const data2021 = [
     // 2021 Online Regionals Finalist Set --- regional2021_1
     {
         "id": null,
+        "block": 0,
         "slug": "regional2021_1",
         "name": "2021 Online Regionals Finalist Set",
         "release": "August 2021",
@@ -1137,6 +1177,7 @@ const data2021 = [
     // 2021 Online Regionals Champion Set --- regional2021_2
     {
         "id": null,
+        "block": 0,
         "slug": "regional2021_2",
         "name": "2021 Online Regionals Champion Set",
         "release": "August 2021",
@@ -1157,6 +1198,7 @@ const data2021 = [
     // Store Championship Participant Pack --- storechampion_0
     {
         "id": null,
+        "block": 0,
         "slug": "storechampion_0",
         "name": "Store Championship Participant Pack",
         "release": "September 13 – October 17, 2021",
@@ -1176,6 +1218,7 @@ const data2021 = [
     // Store Champion Card Set --- storechampion_1
     {
         "id": null,
+        "block": 0,
         "slug": "storechampion_1",
         "name": "Store Champion Card Set",
         "release": "September 13 – October 17, 2021",
@@ -1196,6 +1239,7 @@ const data2021 = [
     // Tamer Party Vol.3 --- tp3
     {
         "id": null,
+        "block": 1,
         "slug": "tp3",
         "name": "Tamer Party Vol.3",
         "release": "September 2021",
@@ -1212,6 +1256,7 @@ const data2021 = [
     // DC-1 Grand Prix --- dc1
     {
         "id": null,
+        "block": 0,
         "slug": "dc1",
         "name": "DC-1 Grand Prix",
         "release": "September-October 2021",
@@ -1229,6 +1274,7 @@ const data2021 = [
     // Double Diamond (BT-06) Pre-Release Tournaments --- bt6_prerelease
     {
         "id": null,
+        "block": 0,
         "slug": "bt6_prerelease",
         "name": "Double Diamond (BT-06) Pre-Release Tournaments",
         "release": "October 8, 2021",
@@ -1245,6 +1291,7 @@ const data2021 = [
     // Starter Deck GALLANTMON [ST-7] --- st7
     {
         "id": "ST7",
+        "block": 1,
         "slug": "st7",
         "name": "Starter Deck GALLANTMON [ST-7]",
         "release": "October 15, 2021",
@@ -1262,6 +1309,7 @@ const data2021 = [
     },
     {
         "id": null,
+        "block": 1,
         "slug": "st7",
         "name": "Starter Deck GALLANTMON [ST-7]",
         "release": "October 15, 2021",
@@ -1277,6 +1325,7 @@ const data2021 = [
     // Starter Deck ULFORCEVEEDRAMON [ST-8] --- st8
     {
         "id": "ST8",
+        "block": 1,
         "slug": "st8",
         "name": "Starter Deck ULFORCEVEEDRAMON [ST-8]",
         "release": "October 15, 2021",
@@ -1294,6 +1343,7 @@ const data2021 = [
     },
     {
         "id": null,
+        "block": 1,
         "slug": "st8",
         "name": "Starter Deck ULFORCEVEEDRAMON [ST-8]",
         "release": "October 15, 2021",
@@ -1309,6 +1359,7 @@ const data2021 = [
     // First Anniversary Promo Pack --- first_anniversary
     {
         "id": null,
+        "block": 1,
         "slug": "first_anniversary",
         "name": "First Anniversary Promo Pack",
         "release": "October 15, 2021",
@@ -1327,6 +1378,7 @@ const data2021 = [
     // Booster Double Diamond [BT6] --- bt6
     {
         "id": "BT6",
+        "block": 1,
         "slug": "bt6",
         "name": "Booster Double Diamond [BT6]",
         "release": "October 15, 2021",
@@ -1355,6 +1407,10 @@ const data2021 = [
     // Booster Double Diamond [BT6] - Alternatives --- bt6_alts
     {
         "id": null,
+        "block": {
+            "0": ["BT1"],
+            "1": ["BT6"]
+        },
         "slug": "bt6_alts",
         "name": "Booster Double Diamond [BT6] - Alternatives",
         "release": "October 15, 2021",
@@ -1384,6 +1440,7 @@ const data2021 = [
     // Booster Double Diamond [BT6] - Box Topper --- bt6_boxtopper
     {
         "id": null,
+        "block": 1,
         "slug": "bt6_boxtopper",
         "name": "Booster Double Diamond [BT6] - Box Topper",
         "release": "October 15, 2021",
@@ -1400,6 +1457,7 @@ const data2021 = [
     // 1-Year Anniversary Promo Pack --- 1year_anniversary
     {
         "id": null,
+        "block": 1,
         "slug": "1year_anniversary",
         "name": "1-Year Anniversary Promo Pack",
         "release": "October 15, 2021",
@@ -1421,6 +1479,7 @@ const data2021 = [
     // Double Diamond Dash Pack --- bt6_dash
     {
         "id": null,
+        "block": 1,
         "slug": "bt6_dash",
         "name": "Double Diamond Dash Pack",
         "release": "October 15, 2021",
@@ -1441,6 +1500,7 @@ const data2021 = [
     // Official Tournament Pack Vol.3 --- otp3
     {
         "id": null,
+        "block": 0,
         "slug": "otp3",
         "name": "Official Tournament Pack Vol.3",
         "release": "October, 2021",
@@ -1484,6 +1544,10 @@ const data2021 = [
     // Winner Pack Double Diamond --- wp3
     {
         "id": null,
+        "block": {
+            "0": ["BT1"],
+            "1": ["BT2","BT3"]
+        },
         "slug": "wp3",
         "name": "Winner Pack Double Diamond",
         "release": "October, 2021",
@@ -1501,6 +1565,7 @@ const data2021 = [
     // Booster Classic Collection [EX1] --- ex1
     {
         "id": "EX1",
+        "block": 1,
         "slug": "ex1",
         "name": "Booster Classic Collection [EX1]",
         "release": "December 10, 2021",
@@ -1529,6 +1594,7 @@ const data2021 = [
     // Booster Classic Collection [EX1] - Alternatives --- ex1_alts
     {
         "id": null,
+        "block": 1,
         "slug": "ex1_alts",
         "name": "Booster Classic Collection [EX1] - Alternatives",
         "release": "December 10, 2021",
@@ -1569,6 +1635,7 @@ const data2021 = [
     // Booster Classic Collection [EX1] - Box Topper --- ex1_boxtopper
     {
         "id": null,
+        "block": 0,
         "slug": "ex1_boxtopper",
         "name": "Booster Classic Collection [EX1] - Box Topper",
         "release": "December 10, 2021",

--- a/js/data/data_2022.js
+++ b/js/data/data_2022.js
@@ -162,7 +162,7 @@ const data2022 = [
     // 2021 Final Championships Framed Trophy Cards - 1st Place Champion --- fcftc_2021_1st
     {
         "id": null,
-        "block": 0, // Posible error de impresión y le corresponda bloque 1
+        "block": 1, // La carta tiene bloque 0, pero es un premio asique lo consideramos por su bloque original 1
         "slug": "fcftc_2021_1st",
         "name": "2021 Final Championships Framed Trophy Cards - 1st Place Champion",
         "release": "January 2022",

--- a/js/data/data_2022.js
+++ b/js/data/data_2022.js
@@ -3,6 +3,7 @@ const data2022 = [
     // 2021 Championship Finals Tamer‘s Evolution Pack --- cf_tamerevolution
     {
         "id": null,
+        "block": 0,
         "slug": "cf_tamerevolution",
         "name": "2021 Championship Finals Tamer‘s Evolution Pack",
         "release": "January 2022",
@@ -23,6 +24,7 @@ const data2022 = [
     // Event Pack 2 --- eventpack2
     {
         "id": null,
+        "block": 0,
         "slug": "eventpack2",
         "name": "Event Pack 2",
         "release": "January 2022",
@@ -40,6 +42,10 @@ const data2022 = [
     },
     {
         "id": null,
+        "block": {
+            "0": ["BT4","BT5"],
+            "1": ["BT6"]
+        },
         "slug": "eventpack2",
         "name": "Event Pack 2",
         "release": "January 2022",
@@ -64,6 +70,7 @@ const data2022 = [
     // Event Pack Alt-Art Gold Stamp Set --- eventpack_goldstamp
     {
         "id": null,
+        "block": 0,
         "slug": "eventpack_goldstamp",
         "name": "Event Pack Alt-Art Gold Stamp Set",
         "release": "January 2022",
@@ -81,6 +88,7 @@ const data2022 = [
     // Judge Pack --- judgepack
     {
         "id": null,
+        "block": 0,
         "slug": "judgepack",
         "name": "Judge Pack",
         "release": "January 2022",
@@ -95,6 +103,7 @@ const data2022 = [
     },
     {
         "id": null,
+        "block": 0,
         "slug": "judgepack",
         "name": "Judge Pack",
         "release": "January 2022",
@@ -114,6 +123,7 @@ const data2022 = [
     // 2021 Final Championships Framed Trophy Cards - Top 16 --- fcftc_2021_top16
     {
         "id": null,
+        "block": 0,
         "slug": "fcftc_2021_top16",
         "name": "2021 Final Championships Framed Trophy Cards - Top 16",
         "release": "January 2022",
@@ -126,6 +136,7 @@ const data2022 = [
     // 2021 Final Championships Framed Trophy Cards - 3rd Place --- fcftc_2021_3rd
     {
         "id": null,
+        "block": 0,
         "slug": "fcftc_2021_3rd",
         "name": "2021 Final Championships Framed Trophy Cards - 3rd Place",
         "release": "January 2022",
@@ -138,6 +149,7 @@ const data2022 = [
     // 2021 Final Championships Framed Trophy Cards - 2nd Place --- fcftc_2021_2nd
     {
         "id": null,
+        "block": 0,
         "slug": "fcftc_2021_2nd",
         "name": "2021 Final Championships Framed Trophy Cards - 2nd Place",
         "release": "January 2022",
@@ -150,6 +162,7 @@ const data2022 = [
     // 2021 Final Championships Framed Trophy Cards - 1st Place Champion --- fcftc_2021_1st
     {
         "id": null,
+        "block": 0, // Posible error de impresión y le corresponda bloque 1
         "slug": "fcftc_2021_1st",
         "name": "2021 Final Championships Framed Trophy Cards - 1st Place Champion",
         "release": "January 2022",
@@ -164,6 +177,7 @@ const data2022 = [
     // Tamer Party Vol.4 --- tp4
     {
         "id": null,
+        "block": 1,
         "slug": "tp4",
         "name": "Tamer Party Vol.4",
         "release": "February 2022",
@@ -176,6 +190,7 @@ const data2022 = [
     },
     {
         "id": null,
+        "block": 1,
         "slug": "tp4",
         "name": "Tamer Party Vol.4",
         "release": "February 2022",
@@ -188,6 +203,10 @@ const data2022 = [
     // Official Tournament Pack Vol.4 --- otp4
     {
         "id": null,
+        "block": {
+            "0": ["BT2"],
+            "1": ["BT3","P"]
+        },
         "slug": "otp4",
         "name": "Official Tournament Pack Vol.4",
         "release": "February, 2022",
@@ -205,6 +224,7 @@ const data2022 = [
     },
     {
         "id": null,
+        "block": 1,
         "slug": "otp4",
         "name": "Official Tournament Pack Vol.4",
         "release": "February 2022",
@@ -218,6 +238,7 @@ const data2022 = [
     // Winner Pack Next Adventure --- wp4
     {
         "id": null,
+        "block": 1,
         "slug": "wp4",
         "name": "Winner Pack Next Adventure",
         "release": "February, 2022",
@@ -231,6 +252,7 @@ const data2022 = [
     },
     {
         "id": null,
+        "block": 1,
         "slug": "wp4",
         "name": "Winner Pack Next Adventure",
         "release": "February 2022",
@@ -245,6 +267,7 @@ const data2022 = [
     // Next Adventure (BT7) Pre-Release Tournaments --- bt7_prerelease
     {
         "id": null,
+        "block": 1,
         "slug": "bt7_prerelease",
         "name": "Next Adventure (BT7) Pre-Release Tournaments",
         "release": "February 25, 2022",
@@ -262,6 +285,7 @@ const data2022 = [
     // Booster Next Adventure [BT7] --- bt7
     {
         "id": "BT7",
+        "block": 1,
         "slug": "bt7",
         "name": "Booster Next Adventure [BT7]",
         "release": "March 4, 2022",
@@ -295,6 +319,7 @@ const data2022 = [
     },
     {
         "id": null,
+        "block": 1,
         "slug": "bt7",
         "name": "Booster Next Adventure [BT7]",
         "release": "March 4, 2022",
@@ -314,6 +339,7 @@ const data2022 = [
     // Booster Next Adventure [BT7] - Alternatives --- bt7_alts
     {
         "id": null,
+        "block": 1,
         "slug": "bt7_alts",
         "name": "Booster Next Adventure [BT7] - Alternatives",
         "release": "March 4, 2022",
@@ -342,6 +368,7 @@ const data2022 = [
     // Booster Next Adventure [BT7] - Box Topper --- bt7_boxtopper
     {
         "id": null,
+        "block": 1,
         "slug": "bt7_boxtopper",
         "name": "Booster Next Adventure [BT7] - Box Topper",
         "release": "March 4, 2022",
@@ -358,6 +385,7 @@ const data2022 = [
     // Box Promotion Pack Next Adventure --- bt7_promotion
     {
         "id": null,
+        "block": 1,
         "slug": "bt7_promotion",
         "name": "Box Promotion Pack Next Adventure",
         "release": "March 4, 2022",
@@ -377,6 +405,10 @@ const data2022 = [
     // 2021 Vault Set --- 2021fest_vault
     {
         "id": null,
+        "block": {
+            "0": ["P-009","P-016","P-028","P-032","BT2"],
+            "1": ["ST7","ST8","P-046"]
+        },
         "slug": "2021fest_vault",
         "name": "2021 Vault Set",
         "release": "March, 2022",
@@ -401,6 +433,10 @@ const data2022 = [
     },
     {
         "id": null,
+        "block": {
+            "0": ["P"],
+            "1": ["BT6"]
+        },
         "slug": "2021fest_vault",
         "name": "2021 Vault Set",
         "release": "March, 2022",
@@ -418,6 +454,10 @@ const data2022 = [
     // Digi-Egg Set --- 2021fest_digiegg
     {
         "id": null,
+        "block": {
+            "0": ["BT2","BT3"],
+            "1": ["BT7"]
+        },
         "slug": "2021fest_digiegg",
         "name": "Digi-Egg Set",
         "release": "March, 2022",
@@ -434,6 +474,10 @@ const data2022 = [
     },
     {
         "id": null,
+        "block": {
+            "0": ["BT4","BT5"],
+            "1": ["BT6"]
+        },
         "slug": "2021fest_digiegg",
         "name": "Digi-Egg Set",
         "release": "March, 2022",
@@ -451,6 +495,7 @@ const data2022 = [
     // Fest Stamp SR --- 2021fest_stamp
     {
         "id": null,
+        "block": 0,
         "slug": "2021fest_stamp",
         "name": "Fest Stamp SR",
         "release": "March, 2022",
@@ -464,6 +509,7 @@ const data2022 = [
     // Fest WINNER Stamp SR --- 2021fest_winner
     {
         "id": null,
+        "block": 0,
         "slug": "2021fest_winner",
         "name": "Fest WINNER Stamp SR",
         "release": "March, 2022",
@@ -477,6 +523,7 @@ const data2022 = [
     // 2021 World Championship --- wc2021
     {
         "id": null,
+        "block": 0,
         "slug": "wc2021",
         "name": "2021 World Championship Participation",
         "release": "March, 2022",
@@ -489,6 +536,7 @@ const data2022 = [
     // 2021 World Championship 3rd Place --- wc2021_3rd
     {
         "id": null,
+        "block": 0,
         "slug": "wc2021_3rd",
         "name": "2021 World Championship Framed Trophy Cards - 3rd Place",
         "release": "March, 2022",
@@ -501,6 +549,7 @@ const data2022 = [
     // 2021 World Championship 2nd Place --- wc2021_2nd
     {
         "id": null,
+        "block": 0,
         "slug": "wc2021_2nd",
         "name": "2021 World Championship Framed Trophy Cards - 2nd Place",
         "release": "March, 2022",
@@ -513,6 +562,7 @@ const data2022 = [
     // 2021 World Championship 1st Place --- wc2021_1st
     {
         "id": null,
+        "block": 0,
         "slug": "wc2021_1st",
         "name": "2021 World Championship Framed Trophy Cards - 1st Place",
         "release": "March, 2022",
@@ -527,6 +577,10 @@ const data2022 = [
     // Tamer's Evolution Box2 [PB-06] --- pb6
     {
         "id": null,
+        "block": {
+            "0": ["BT2","BT3","BT4","BT5","P"],
+            "1": ["EX1","ST7"]
+        },
         "slug": "pb6",
         "name": "Tamer's Evolution Box2 [PB-06]",
         "release": "May, 2022",
@@ -549,6 +603,7 @@ const data2022 = [
     // New Awakening (BT8) Pre-Release Tournaments --- bt8_prerelease
     {
         "id": null,
+        "block": 1,
         "slug": "bt8_prerelease",
         "name": "New Awakening (BT8) Pre-Release Tournaments",
         "release": "May 6, 2022",
@@ -562,6 +617,7 @@ const data2022 = [
     },
     {
         "id": null,
+        "block": 1,
         "slug": "bt8_prerelease",
         "name": "New Awakening (BT8) Pre-Release Tournaments",
         "release": "May 6, 2022",
@@ -577,6 +633,7 @@ const data2022 = [
     // Starter Deck ULTIMATE ANCIENT DRAGON [ST-9] --- st9
     {
         "id": "ST9",
+        "block": 1,
         "slug": "st9",
         "name": "Starter Deck ULTIMATE ANCIENT DRAGON [ST-9]",
         "release": "May 13, 2022",
@@ -603,6 +660,7 @@ const data2022 = [
     // Starter Deck PARALLEL WORLD TACTICIAN [ST-10] --- st10
     {
         "id": "ST10",
+        "block": 1,
         "slug": "st10",
         "name": "Starter Deck PARALLEL WORLD TACTICIAN [ST-10]",
         "release": "May 13, 2022",
@@ -630,6 +688,7 @@ const data2022 = [
     // Booster New Awakening [BT8] --- bt8
     {
         "id": "BT8",
+        "block": 1,
         "slug": "bt8",
         "name": "Booster New Awakening [BT8]",
         "release": "May 13, 2022",
@@ -676,6 +735,7 @@ const data2022 = [
     // Booster New Awakening [BT8] - Alternatives --- bt8_alts
     {
         "id": null,
+        "block": 1,
         "slug": "bt8_alts",
         "name": "Booster New Awakening [BT8] - Alternatives",
         "release": "May 13, 2022",
@@ -704,6 +764,7 @@ const data2022 = [
     // Booster New Awakening [BT8] - Box Topper --- bt8_boxtopper
     {
         "id": null,
+        "block": 1,
         "slug": "bt8_boxtopper",
         "name": "Booster New Awakening [BT8] - Box Topper",
         "release": "May 13, 2022",
@@ -720,6 +781,7 @@ const data2022 = [
     // Booster New Awakening [BT8] - Promo Box Topper --- bt8_promoboxtopper
     {
         "id": null,
+        "block": 1,
         "slug": "bt8_promoboxtopper",
         "name": "Booster New Awakening [BT8] - Promo Box Topper",
         "release": "May 13, 2022",
@@ -734,6 +796,10 @@ const data2022 = [
     // Fest Set --- 2021fest
     {
         "id": null,
+        "block": {
+            "0": ["BT2"],
+            "1": ["BT7"]
+        },
         "slug": "2021fest",
         "name": "Fest Set",
         "release": "March, 2022",
@@ -754,8 +820,13 @@ const data2022 = [
     },
     {
         "id": null,
+        "block": {
+            "0": ["BT1","BT4","BT5"],
+            "1": ["BT6","BT8"]
+        },
         "slug": "2021fest",
         "name": "Fest Set",
+        // TODO: revisar block
         "release": "March, 2022",
         "url": "digimoncardURL/setID-cardID_parallel.png",
         "cards": {
@@ -779,6 +850,7 @@ const data2022 = [
     // Ultimate Cup --- ultimatecup
     {
         "id": null,
+        "block": 0,
         "slug": "ultimatecup",
         "name": "Ultimate Cup",
         "release": "April, 2022",
@@ -790,6 +862,10 @@ const data2022 = [
     },
     {
         "id": null,
+        "block": {
+            "0": ["BT1","BT3"],
+            "1": ["BT8","EX1","ST9"]
+        },
         "slug": "ultimatecup",
         "name": "Ultimate Cup",
         "release": "April, 2022",
@@ -809,6 +885,7 @@ const data2022 = [
     // Booster Digital Hazard [EX2] --- ex2
     {
         "id": "EX2",
+        "block": 1,
         "slug": "ex2",
         "name": "Booster Digital Hazard [EX2]",
         "release": "June 24, 2022",
@@ -845,6 +922,7 @@ const data2022 = [
     // Booster Digital Hazard [EX2] - Alternatives --- ex2_alts
     {
         "id": null,
+        "block": 1,
         "slug": "ex2_alts",
         "name": "Booster Digital Hazard [EX2] - Alternatives",
         "release": "June 24, 2022",
@@ -885,6 +963,7 @@ const data2022 = [
     // Booster Digital Hazard [EX2] - Box Topper --- ex2_boxtopper
     {
         "id": null,
+        "block": 1,
         "slug": "ex2_boxtopper",
         "name": "Booster Digital Hazard [EX2] - Box Topper",
         "release": "June 24, 2022",
@@ -899,6 +978,7 @@ const data2022 = [
     // Playmat and Card Set 1 Digimon Tamers [PB-08] --- pb8
     {
         "id": null,
+        "block": 1,
         "slug": "pb8",
         "name": "Playmat and Card Set 1 Digimon Tamers [PB-08]",
         "release": "June, 2022",
@@ -920,6 +1000,10 @@ const data2022 = [
     // Tamer Party Vol.5 --- tp5
     {
         "id": null,
+        "block": {
+            "0": ["BT3","BT5"],
+            "1": ["BT6"]
+        },
         "slug": "tp5",
         "name": "Tamer Party Vol.5",
         "release": "June 2022",
@@ -934,6 +1018,7 @@ const data2022 = [
     // Official Tournament Pack Vol.5 --- otp5
     {
         "id": null,
+        "block": 1,
         "slug": "otp5",
         "name": "Official Tournament Pack Vol.5",
         "release": "June, 2022",
@@ -952,6 +1037,7 @@ const data2022 = [
     // Winner Pack New Awakening --- wp5
     {
         "id": null,
+        "block": 1,
         "slug": "wp5",
         "name": "Winner Pack New Awakening",
         "release": "June, 2022",
@@ -963,6 +1049,7 @@ const data2022 = [
     },
     {
         "id": null,
+        "block": 1,
         "slug": "wp5",
         "name": "Winner Pack New Awakening",
         "release": "June, 2022",
@@ -979,6 +1066,10 @@ const data2022 = [
     // Summer 2022 Dash Pack --- 2022summer_dashpack
     {
         "id": null,
+        "block": {
+            "0": ["BT5"],
+            "1": ["BT7","BT8"]
+        },
         "slug": "2022summer_dashpack",
         "name": "Summer 2022 Dash Pack",
         "release": "July 1, 2022",
@@ -992,6 +1083,7 @@ const data2022 = [
     // Digimon Survive Promo Pack --- digimon_survive
     {
         "id": null,
+        "block": 2,
         "slug": "digimon_survive",
         "name": "Digimon Survive Promo Pack",
         "release": "July 1, 2022",
@@ -1008,6 +1100,10 @@ const data2022 = [
     // X Record (BT9) Pre-Release Tournaments --- bt9_prerelease
     {
         "id": null,
+        "block": {
+            "1": ["BT5"],
+            "2": ["EX1"]
+        },
         "slug": "bt9_prerelease",
         "name": "X Record (BT9) Pre-Release Tournaments",
         "release": "July 22, 2022",
@@ -1024,6 +1120,7 @@ const data2022 = [
     // Booster X Record [BT9] --- bt9
     {
         "id": "BT9",
+        "block": 1,
         "slug": "bt9",
         "name": "Booster X Record [BT9]",
         "release": "July 29, 2022",
@@ -1065,6 +1162,7 @@ const data2022 = [
     // Booster X Record [BT9] - Alternatives --- bt9_alts
     {
         "id": null,
+        "block": 1,
         "slug": "bt9_alts",
         "name": "Booster X Record [BT9] - Alternatives",
         "release": "July 29, 2022",
@@ -1093,6 +1191,7 @@ const data2022 = [
     // Booster X Record [BT9] - Box Topper --- bt9_boxtopper
     {
         "id": null,
+        "block": 1,
         "slug": "bt9_boxtopper",
         "name": "Booster X Record [BT9] - Box Topper",
         "release": "July 29, 2022",
@@ -1109,6 +1208,7 @@ const data2022 = [
     // Box Promotion Pack Update Pack --- bt9_promotion
     {
         "id": null,
+        "block": 1,
         "slug": "bt9_promotion",
         "name": "Box Promotion Pack Update Pack",
         "release": "July 29, 2022",
@@ -1129,6 +1229,10 @@ const data2022 = [
     // 2022 Regionals Participation Set --- regional2022_0
     {
         "id": null,
+        "block": {
+            "0": ["BT4"],
+            "1": ["BT6","BT7","ST8","EX1"]
+        },
         "slug": "regional2022_0",
         "name": "2022 Regionals Participation Set",
         "release": "July, 2022",
@@ -1147,6 +1251,10 @@ const data2022 = [
     // 2022 Regionals Finalist Set --- regional2022_1
     {
         "id": null,
+        "block": {
+            "0": ["BT4"],
+            "1": ["BT6","BT7","ST8","EX1"]
+        },
         "slug": "regional2022_1",
         "name": "2022 Regionals Finalist Set",
         "release": "July, 2022",
@@ -1165,6 +1273,10 @@ const data2022 = [
     // 2022 Regionals Champion Set --- regional2022_2
     {
         "id": null,
+        "block": {
+            "0": ["BT4"],
+            "1": ["BT6","BT7","ST8","EX1"]
+        },
         "slug": "regional2022_2",
         "name": "2022 Regionals Champion Set",
         "release": "July, 2022",
@@ -1183,6 +1295,10 @@ const data2022 = [
     // Official Tournament Pack Vol.6 --- otp6
     {
         "id": null,
+        "block": {
+            "0": ["BT1-076","ST1","ST2","ST3"],
+            "2": ["BT1-072","BT7"]
+        },
         "slug": "otp6",
         "name": "Official Tournament Pack Vol.6",
         "release": "July, 2022",
@@ -1200,6 +1316,7 @@ const data2022 = [
     // Winner Pack X Record --- wp6
     {
         "id": null,
+        "block": 1,
         "slug": "wp6",
         "name": "Winner Pack X Record",
         "release": "July, 2022",
@@ -1212,6 +1329,7 @@ const data2022 = [
     },
     {
         "id": null,
+        "block": 1,
         "slug": "wp6",
         "name": "Winner Pack X Record",
         "release": "July, 2022",
@@ -1227,6 +1345,7 @@ const data2022 = [
     // Store Championship 2022 Participant Pack --- storechampion_2022_0
     {
         "id": null,
+        "block": 1,
         "slug": "storechampion_2022_0",
         "name": "Store Championship 2022 Participant Pack",
         "release": "August, 2022",
@@ -1239,6 +1358,7 @@ const data2022 = [
     },
     {
         "id": null,
+        "block": 1,
         "slug": "storechampion_2022_0",
         "name": "Store Championship 2022 Participant Pack",
         "release": "August, 2022",
@@ -1257,6 +1377,7 @@ const data2022 = [
     // Store Championship 2022 Champion Card Set --- storechampion_2022_1
     {
         "id": null,
+        "block": 1,
         "slug": "storechampion_2022_1",
         "name": "Store Championship 2022 Champion Card Set",
         "release": "August, 2022",
@@ -1268,6 +1389,7 @@ const data2022 = [
     },
     {
         "id": null,
+        "block": 1,
         "slug": "storechampion_2022_1",
         "name": "Store Championship 2022 Champion Card Set",
         "release": "August, 2022",
@@ -1285,6 +1407,7 @@ const data2022 = [
     // 2022 Regionals Participant Card Set 2 --- regional2022_2_0
     {
         "id": null,
+        "block": 1,
         "slug": "regional2022_2_0",
         "name": "2022 Regionals Participant Card Set 2",
         "release": "July, 2022",
@@ -1297,6 +1420,10 @@ const data2022 = [
     },
     {
         "id": null,
+        "block": {
+            "0": ["BT5"],
+            "1": ["BT7","BT8","ST7"]
+        },
         "slug": "regional2022_2_0",
         "name": "2022 Regionals Participant Card Set 2",
         "release": "July, 2022",
@@ -1313,6 +1440,7 @@ const data2022 = [
     // 2022 Regionals Finalist Card Set 2 --- regional2022_2_1
     {
         "id": null,
+        "block": 1,
         "slug": "regional2022_2_1",
         "name": "2022 Regionals Finalist Card Set 2",
         "release": "July, 2022",
@@ -1325,6 +1453,10 @@ const data2022 = [
     },
     {
         "id": null,
+        "block": {
+            "0": ["BT5"],
+            "1": ["BT7","BT8","ST7"]
+        },
         "slug": "regional2022_2_1",
         "name": "2022 Regionals Finalist Card Set 2",
         "release": "July, 2022",
@@ -1341,6 +1473,7 @@ const data2022 = [
     // 2022 Regionals Champion Card Set 2 --- regional2022_2_2
     {
         "id": null,
+        "block": 1,
         "slug": "regional2022_2_2",
         "name": "2022 Regionals Champion Card Set 2",
         "release": "July, 2022",
@@ -1353,6 +1486,10 @@ const data2022 = [
     },
     {
         "id": null,
+        "block": {
+            "0": ["BT5"],
+            "1": ["BT7","BT8","ST7"]
+        },
         "slug": "regional2022_2_2",
         "name": "2022 Regionals Champion Card Set 2",
         "release": "July, 2022",
@@ -1371,6 +1508,7 @@ const data2022 = [
     // Playmat and Card Set 2 Floral Fun [PB-09] --- pb9
     {
         "id": null,
+        "block": 1,
         "slug": "pb9",
         "name": "Playmat and Card Set 2 Floral Fun [PB-09]",
         "release": "September, 2022",
@@ -1392,6 +1530,7 @@ const data2022 = [
     // Premium Deck Set [PD-01] --- pd1
     {
         "id": null,
+        "block": 1,
         "slug": "pd1",
         "name": "Premium Deck Set [PD-01]",
         "release": "September 30, 2022",
@@ -1406,6 +1545,7 @@ const data2022 = [
     // Premium Deck Set Lucky Pack [PD-01] --- pd1_lucky
     {
         "id": null,
+        "block": 1,
         "slug": "pd1_lucky",
         "name": "Premium Deck Set Lucky Pack [PD-01]",
         "release": "September 30, 2022",
@@ -1420,6 +1560,7 @@ const data2022 = [
     },
     {
         "id": null,
+        "block": 0,
         "slug": "pd1_lucky",
         "name": "Premium Deck Set Lucky Pack [PD-01]",
         "release": "September 30, 2022",
@@ -1434,6 +1575,7 @@ const data2022 = [
     // Tamer Party Vol.6 --- tp6
     {
         "id": null,
+        "block": 2,
         "slug": "tp6",
         "name": "Tamer Party Vol.6",
         "release": "October 2022",
@@ -1448,6 +1590,10 @@ const data2022 = [
     // Event Pack 3 --- eventpack3
     {
         "id": null,
+        "block": {
+            "0": ["P"],
+            "1": ["BT6","BT7"]
+        },
         "slug": "eventpack3",
         "name": "Event Pack 3",
         "release": "October 2022",
@@ -1477,6 +1623,7 @@ const data2022 = [
     // 2022 DC-1 Tournament --- dc1_2022
     {
         "id": null,
+        "block": 1,
         "slug": "dc1_2022",
         "name": "2022 DC-1 Tournament",
         "release": "October 2022",
@@ -1495,6 +1642,10 @@ const data2022 = [
     // Official Tournament Pack Vol.7 --- otp7
     {
         "id": null,
+        "block": {
+            "1": ["BT3","ST6"],
+            "2": ["BT1","BT5","EX1"]
+        },
         "slug": "otp7",
         "name": "Official Tournament Pack Vol.7",
         "release": "October 2022–February 2023",
@@ -1512,6 +1663,7 @@ const data2022 = [
     // Winner Pack Xros Encounter --- wp7
     {
         "id": null,
+        "block": 1,
         "slug": "wp7",
         "name": "Winner Pack -Xros Encounter-",
         "release": "October 2022–February 2023",
@@ -1524,6 +1676,9 @@ const data2022 = [
     },
     {
         "id": null,
+        "block": {
+            "1": ["BT1"],
+            "2": ["BT7"]},
         "slug": "wp7",
         "name": "Winner Pack -Xros Encounter-",
         "release": "October 2022–February 2023",
@@ -1539,6 +1694,7 @@ const data2022 = [
     // Xros Encounter (BT10) Pre-Release Tournaments --- bt10_prerelease
     {
         "id": null,
+        "block": 2,
         "slug": "bt10_prerelease",
         "name": "Xros Encounter (BT10) Pre-Release Tournaments",
         "release": "October 7, 2022",
@@ -1556,6 +1712,7 @@ const data2022 = [
     // Starter Deck JESMON [ST-12] --- st12
     {
         "id": "ST12",
+        "block": 2,
         "slug": "st12",
         "name": "Starter Deck JESMON [ST-12]",
         "release": "October 14, 2022",
@@ -1579,6 +1736,7 @@ const data2022 = [
     // Starter Deck RagnaLoardmon [ST-13] --- st13
     {
         "id": "ST13",
+        "block": 2,
         "slug": "st13",
         "name": "Starter Deck RagnaLoardmon [ST-13]",
         "release": "October 14, 2022",
@@ -1602,6 +1760,7 @@ const data2022 = [
     // Bonus Tamer Cards Pack --- bonus_tamer_cards
     {
         "id": null,
+        "block": 2,
         "slug": "bonus_tamer_cards",
         "name": "Bonus Tamer Cards Pack",
         "release": "October 14, 2022",
@@ -1619,6 +1778,7 @@ const data2022 = [
     // Booster Xros Encounter [BT10] --- bt10
     {
         "id": "BT10",
+        "block": 2,
         "slug": "bt10",
         "name": "Booster Xros Encounter [BT10]",
         "release": "October 14, 2022",
@@ -1654,6 +1814,10 @@ const data2022 = [
     // Booster Xros Encounter [BT10] - Alternatives --- bt10_alts
     {
         "id": null,
+        "block": {
+            "1": ["BT6"],
+            "2": ["BT10"]
+        },
         "slug": "bt10_alts",
         "name": "Booster Xros Encounter [BT10] - Alternatives",
         "release": "October 14, 2022",
@@ -1685,6 +1849,7 @@ const data2022 = [
     // Booster Xros Encounter [BT10] - Box Topper --- bt10_boxtopper
     {
         "id": null,
+        "block": 2,
         "slug": "bt10_boxtopper",
         "name": "Booster Xros Encounter [BT10] - Box Topper",
         "release": "October 14, 2022",
@@ -1701,6 +1866,7 @@ const data2022 = [
     // Box Promotion Pack ST-11 Special Entry pack --- st11
     {
         "id": null,
+        "block": 1,
         "slug": "st11",
         "name": "Box Promotion Pack ST-11 Special Entry pack",
         "release": "October 14, 2022",
@@ -1727,6 +1893,7 @@ const data2022 = [
     },
     {
         "id": null,
+        "block": 1,
         "slug": "st11",
         "name": "Box Promotion Pack ST-11 Special Entry pack",
         "release": "October 14, 2022",
@@ -1739,6 +1906,10 @@ const data2022 = [
     // 25th Special Memorial Pack --- 25specialmemorial
     {
         "id": null,
+        "block": {
+            "0": ["BT1","BT2","BT3","BT5","P"],
+            "1": ["BT6","BT7","BT8"]
+        },
         "slug": "25specialmemorial",
         "name": "25th Special Memorial Pack",
         "release": "October 14, 2022",
@@ -1764,6 +1935,7 @@ const data2022 = [
     // Gift Box 2022 [GB-02] --- gb2
     {
         "id": null,
+        "block": 0,
         "slug": "gb2",
         "name": "Gift Box 2022 [GB-02]",
         "release": "November 4, 2022",
@@ -1777,6 +1949,7 @@ const data2022 = [
     },
     {
         "id": null,
+        "block": 0,
         "slug": "gb2",
         "name": "Gift Box 2022 [GB-02]",
         "release": "November 4, 2022",
@@ -1790,6 +1963,7 @@ const data2022 = [
     // Booster Draconic Roar [EX3] --- ex3
     {
         "id": "EX3",
+        "block": 2,
         "slug": "ex3",
         "name": "Booster Draconic Roar [EX3]",
         "release": "November 11, 2022",
@@ -1829,6 +2003,7 @@ const data2022 = [
     // Booster Draconic Roar [EX3] - Alternatives --- ex3_alts
     {
         "id": null,
+        "block": 2,
         "slug": "ex3_alts",
         "name": "Booster Draconic Roar [EX3] - Alternatives",
         "release": "November 11, 2022",
@@ -1857,6 +2032,10 @@ const data2022 = [
     // Booster Draconic Roar [EX3] - Box Topper --- ex3_boxtopper
     {
         "id": null,
+        "block": {
+            "0": ["BT3"],
+            "2": ["EX3"]
+        },
         "slug": "ex3_boxtopper",
         "name": "Booster Draconic Roar [EX3] - Box Topper",
         "release": "November 11, 2022",

--- a/js/data/data_2023.js
+++ b/js/data/data_2023.js
@@ -676,8 +676,8 @@ const data2023 = [
     {
         "id": null,
         "block": {
-            "0": ["BT6","BT7","BT8"],
-            "1": ["BT10","ST12","ST13"]
+            "1": ["BT6","BT7","BT8"],
+            "2": ["BT10","ST12","ST13"]
         },
         "slug": "judgepack3",
         "name": "Judge Pack 3",
@@ -838,8 +838,8 @@ const data2023 = [
     {
         "id": null,
         "block": {
-            "1": ["BT8","EX2","BT12-001"],
-            "2": ["BT12-007","BT12-010","BT12-016","BT12-018"]
+            "1": ["BT8","EX2"],
+            "2": ["BT12"] // BT12-001 tiene bloque 1, pero es un premio asique lo consideramos por su bloque original 2.
         },
         "slug": "ultimatecup_2023",
         "name": "Ultimate Cup 2023",
@@ -972,7 +972,7 @@ const data2023 = [
         "id": null,
         "block": {
             "1": ["BT6","ST9","ST10"],
-            "1": ["BT10","BT11","ST13"]
+            "2": ["BT10","BT11","ST13"]
         },
         "slug": "storechampion_2023_0",
         "name": "Store Championship 2023 Participant Pack",
@@ -995,7 +995,7 @@ const data2023 = [
         "id": null,
         "block": {
             "1": ["BT6","ST9","ST10"],
-            "1": ["BT10","BT11","ST13"]
+            "2": ["BT10","BT11","ST13"]
         },
         "slug": "storechampion_2023_1",
         "name": "Store Championship 2023 Top 4 Pack",

--- a/js/data/data_2023.js
+++ b/js/data/data_2023.js
@@ -3,6 +3,7 @@ const data2023 = [
     // SCSA D-Scanner Promo Card --- dscanner
     {
         "id": null,
+        "block": 1,
         "slug": "dscanner",
         "name": "SCSA D-Scanner Promo Card",
         "release": "January, 2023",
@@ -17,6 +18,10 @@ const data2023 = [
     // 2022 Championship Finals Event Pack Alt-Art Gold Stamp Set --- eventpack_goldstamp_2022
     {
         "id": null,
+        "block": {
+            "0": ["P"],
+            "1": ["BT6","BT7"]
+        },
         "slug": "eventpack_goldstamp_2022",
         "name": "2022 Championship Finals Event Pack Alt-Art Gold Stamp Set",
         "release": "February 2023",
@@ -35,6 +40,7 @@ const data2023 = [
     // 2022 Championship Finals Digimon Tamers Pack --- tamerpack_goldstamp
     {
         "id": null,
+        "block": 1,
         "slug": "tamerpack_goldstamp",
         "name": "2022 Championship Finals Digimon Tamers Pack",
         "release": "February 2023",
@@ -56,6 +62,7 @@ const data2023 = [
     // 2022 Final Championships Framed Trophy Cards - Top 16 --- fcftc_2022_top16
     {
         "id": null,
+        "block": 1,
         "slug": "fcftc_2022_top16",
         "name": "2022 Final Championships Framed Trophy Cards - Top 16",
         "release": "February 2023",
@@ -68,6 +75,7 @@ const data2023 = [
     // 2022 Final Championships Framed Trophy Cards - 3rd Place --- fcftc_2022_3rd
     {
         "id": null,
+        "block": 1,
         "slug": "fcftc_2022_3rd",
         "name": "2022 Final Championships Framed Trophy Cards - 3rd Place",
         "release": "February 2023",
@@ -80,6 +88,7 @@ const data2023 = [
     // 2022 Final Championships Framed Trophy Cards - 2nd Place --- fcftc_2022_2nd
     {
         "id": null,
+        "block": 1,
         "slug": "fcftc_2022_2nd",
         "name": "2022 Final Championships Framed Trophy Cards - 2nd Place",
         "release": "February 2023",
@@ -92,6 +101,7 @@ const data2023 = [
     // 2022 Final Championships Framed Trophy Cards - 1st Place Champion --- fcftc_2022_1st
     {
         "id": null,
+        "block": 1,
         "slug": "fcftc_2022_1st",
         "name": "2022 Final Championships Framed Trophy Cards - 1st Place Champion",
         "release": "February 2023",
@@ -104,6 +114,7 @@ const data2023 = [
     // Tamer Party Vol.7 --- tp7
     {
         "id": null,
+        "block": 2,
         "slug": "tp7",
         "name": "Tamer Party Vol.7",
         "release": "February 2023",
@@ -121,6 +132,7 @@ const data2023 = [
     // Dimensional Phase (BT11) Pre-Release Tournaments --- bt11_prerelease
     {
         "id": null,
+        "block": 1,
         "slug": "bt11_prerelease",
         "name": "Dimensional Phase (BT11) Pre-Release Tournaments",
         "release": "February 10 - February 16, 2023",
@@ -137,6 +149,7 @@ const data2023 = [
     // Booster Dimensional Phase [BT11] --- bt11
     {
         "id": "BT11",
+        "block": 2,
         "slug": "bt11",
         "name": "Booster Dimensional Phase [BT11]",
         "release": "February 17, 2023",
@@ -177,6 +190,11 @@ const data2023 = [
     // Booster Dimensional Phase [BT11] - Alternatives --- bt11_alts
     {
         "id": null,
+        "block": {
+            "0": ["BT2"],
+            "1": ["EX1","ST10"],
+            "2": ["BT11"]
+        },
         "slug": "bt11_alts",
         "name": "Booster Dimensional Phase [BT11] - Alternatives",
         "release": "February 17, 2023",
@@ -208,6 +226,7 @@ const data2023 = [
     // Booster Dimensional Phase [BT11] - Foils --- bt11_foils
     {
         "id": null,
+        "block": 2,
         "slug": "bt11_foils",
         "name": "Booster Dimensional Phase [BT11] - Foils",
         "release": "February 17, 2023",
@@ -296,6 +315,7 @@ const data2023 = [
     // Digimon Illustration Competition Pack --- ilustration_pack
     {
         "id": null,
+        "block": 2,
         "slug": "ilustration_pack",
         "name": "Digimon Illustration Competition Pack",
         "release": "February 17, 2023",
@@ -315,6 +335,10 @@ const data2023 = [
     // English Version 2nd Anniversary Alternate Art Poll - 2ndanniversary_artpoll
     {
         "id": null,
+        "block": {
+            "0": ["BT1","BT2","BT3","BT4","BT5"],
+            "1": ["BT6","BT7"],
+        },
         "slug": "2ndanniversary_artpoll",
         "name": "English Version 2nd Anniversary Alternate Art Poll",
         "release": "February 17, 2023",
@@ -337,6 +361,7 @@ const data2023 = [
     // Official Tournament Pack Vol.8 --- otp8
     {
         "id": null,
+        "block": 2,
         "slug": "ot8",
         "name": "Official Tournament Pack Vol.8",
         "release": "Mid January 2023–April 2023",
@@ -354,6 +379,7 @@ const data2023 = [
     // Winner Pack Dimensional Phase --- wp8
     {
         "id": null,
+        "block": 2,
         "slug": "wp8",
         "name": "Winner Pack -Dimensional Phase-",
         "release": "Mid January 2023–April 2023",
@@ -369,6 +395,10 @@ const data2023 = [
     // Judge Pack 2 --- judgepack2
     {
         "id": null,
+        "block": {
+            "0": ["ST1","ST2","ST3","ST4","ST5","ST6"],
+            "1": ["ST7","ST8","ST9","ST10"]
+        },
         "slug": "judgepack2",
         "name": "Judge Pack 2",
         "release": "Mid January 2023–April 2023",
@@ -392,6 +422,10 @@ const data2023 = [
     // 2nd Anniversary Set [PB-12E] --- pb12e
     {
         "id": null,
+        "block": {
+            "0": ["BT1","BT3","P"],
+            "1": ["BT7"]
+        },
         "slug": "pb12e",
         "name": "2nd Anniversary Set [PB-12E]",
         "release": "March, 2023",
@@ -433,6 +467,7 @@ const data2023 = [
     // 2022 World Championship - Participation --- wc2022
     {
         "id": null,
+        "block": 1,
         "slug": "wc2022",
         "name": "2022 World Championship - Participation",
         "release": "March 11,12,18, 2023",
@@ -445,6 +480,7 @@ const data2023 = [
     // 2022 World Championship 3rd Place --- wc2022_3rd
     {
         "id": null,
+        "block": 1,
         "slug": "wc2022_3rd",
         "name": "2022 World Championship - 3rd Place",
         "release": "March 11,12,18, 2023",
@@ -457,6 +493,7 @@ const data2023 = [
     // 2022 World Championship 2nd Place --- wc2022_2nd
     {
         "id": null,
+        "block": 1,
         "slug": "wc2022_2nd",
         "name": "2022 World Championship - 2nd Place",
         "release": "March 11,12,18, 2023",
@@ -469,6 +506,7 @@ const data2023 = [
     // 2022 World Championship 1st Place --- wc2022_1st
     {
         "id": null,
+        "block": 1,
         "slug": "wc2022_1st",
         "name": "2022 World Championship - 1st Place",
         "release": "March 11,12,18, 2023",
@@ -481,6 +519,7 @@ const data2023 = [
     // 2022 World Championship - Special Multi-Region Match --- wc2022_specialmatch
     {
         "id": null,
+        "block": 1,
         "slug": "wc2022_specialmatch",
         "name": "2022 World Championship - Special Multi-Region Match",
         "release": "March 19, 2023",
@@ -495,6 +534,7 @@ const data2023 = [
     // Advanced Deck Set (ST14) Pre-Release BEELZEMON CUP --- st14_prerelease
     {
         "id": null,
+        "block": 1,
         "slug": "st14_prerelease",
         "name": "Advanced Deck Set (ST14) Pre-Release BEELZEMON CUP",
         "release": "March 17 – March 23, 2023",
@@ -515,6 +555,7 @@ const data2023 = [
     // Advanced Deck BEELZEMON [ST-14] --- st14
     {
         "id": "ST14",
+        "block": 2,
         "slug": "st14",
         "name": "Advanced Deck BEELZEMON [ST-14]",
         "release": "March 24, 2023",
@@ -535,6 +576,7 @@ const data2023 = [
     // Advanced Deck BEELZEMON [ST-14] - Alternatives --- st14_alts
     {
         "id": null,
+        "block": 2,
         "slug": "st14_alts",
         "name": "Advanced Deck BEELZEMON [ST-14] - Alternatives",
         "release": "March 24, 2023",
@@ -556,6 +598,7 @@ const data2023 = [
     // Advanced Deck BEELZEMON [ST-14] - Special Reprints --- st14_spe_rep
     {
         "id": null,
+        "block": 2,
         "slug": "st14_spe_rep",
         "name": "Advanced Deck BEELZEMON [ST-14] - Special Reprints",
         "release": "March 24, 2023",
@@ -577,6 +620,7 @@ const data2023 = [
     // Official Tournament April 2023 Beelzemon Special --- ot_beelzemon
     {
         "id": null,
+        "block": 1,
         "slug": "ot_beelzemon",
         "name": "Official Tournament April 2023 Beelzemon Special",
         "release": "April, 2023",
@@ -597,6 +641,11 @@ const data2023 = [
     // Event Pack 4 --- eventpack4
     {
         "id": null,
+        "block": {
+            "0": ["BT2","BT3"],
+            "1": ["BT6","BT7","BT8","BT9","EX2","P"],
+            "2": ["BT10","ST12"]
+        },
         "slug": "eventpack4",
         "name": "Event Pack 4",
         "release": "March-April, 2023",
@@ -626,6 +675,10 @@ const data2023 = [
     // Judge Pack 3 --- judgepack3
     {
         "id": null,
+        "block": {
+            "0": ["BT6","BT7","BT8"],
+            "1": ["BT10","ST12","ST13"]
+        },
         "slug": "judgepack3",
         "name": "Judge Pack 3",
         "release": "March-April, 2023",
@@ -649,6 +702,7 @@ const data2023 = [
     // Across Time (BT12) Pre-Release Tournaments --- bt12_prerelease
     {
         "id": null,
+        "block": 0,
         "slug": "bt12_prerelease",
         "name": "Across Time (BT12) Pre-Release Tournaments",
         "release": "April 21 - April 28, 2023",
@@ -665,6 +719,7 @@ const data2023 = [
     // Booster Across Time [BT12] --- bt12
     {
         "id": "BT12",
+        "block": 2,
         "slug": "bt12",
         "name": "Booster Across Time [BT12]",
         "release": "April 28, 2023",
@@ -706,6 +761,7 @@ const data2023 = [
     // Booster Across Time [BT12] - Alternatives --- bt12_alts
     {
         "id": null,
+        "block": 2,
         "slug": "bt12_alts",
         "name": "Booster Across Time [BT12] - Alternatives",
         "release": "April 28, 2023",
@@ -734,6 +790,10 @@ const data2023 = [
     // Booster Across Time [BT12] - Box Promotion Pack --- bt12_boxpromopack
     {
         "id": null,
+        "block": {
+            "0": ["BT5"],
+            "2": ["BT12"]
+        },
         "slug": "bt12_boxpromopack",
         "name": "Booster Across Time [BT12] - Box Promotion Pack",
         "release": "April 28, 2023",
@@ -758,6 +818,7 @@ const data2023 = [
     // Booster Across Time [BT12] - Limited Card Pack --- bt12_limitedcardpack
     {
         "id": null,
+        "block": 1,
         "slug": "bt12_limitedcardpack",
         "name": "Booster Across Time [BT12] - Limited Card Pack",
         "release": "April 28, 2023",
@@ -776,6 +837,10 @@ const data2023 = [
     // Ultimate Cup 2023 --- ultimatecup_2023
     {
         "id": null,
+        "block": {
+            "1": ["BT8","EX2","BT12-001"],
+            "2": ["BT12-007","BT12-010","BT12-016","BT12-018"]
+        },
         "slug": "ultimatecup_2023",
         "name": "Ultimate Cup 2023",
         "release": "March-April, 2023",
@@ -794,6 +859,11 @@ const data2023 = [
     // 2023 Regionals Participant Set 1 --- regional2023_1_0
     {
         "id": null,
+        "block": {
+            "0": ["BT2","BT4","P"],
+            "1": ["BT8","EX2","ST9"],
+            "2": ["BT12"]
+        },
         "slug": "regional2023_1_0",
         "name": "2023 Regionals Participant Set 1",
         "release": "March-April, 2023",
@@ -812,6 +882,11 @@ const data2023 = [
     // 2023 Regionals Finalist Set 1 --- regional2023_1_1
     {
         "id": null,
+        "block": {
+            "0": ["BT2","BT4","P"],
+            "1": ["BT8","EX2","ST9"],
+            "2": ["BT12"]
+        },
         "slug": "regional2023_1_1",
         "name": "2023 Regionals Finalist Set 1",
         "release": "March-April, 2023",
@@ -830,6 +905,11 @@ const data2023 = [
     // 2023 Regionals Champion Set 1 --- regional2023_1_2
     {
         "id": null,
+        "block": {
+            "0": ["BT2","BT4","P"],
+            "1": ["BT8","EX2","ST9"],
+            "2": ["BT12"]
+        },
         "slug": "regional2023_1_2",
         "name": "2023 Regionals Champion Set 1",
         "release": "March-April, 2023",
@@ -850,6 +930,7 @@ const data2023 = [
     // Official Tournament Pack Vol.9 --- otp9
     {
         "id": null,
+        "block": 1,
         "slug": "ot9",
         "name": "Official Tournament Pack Vol.9",
         "release": "Late April - July 2023",
@@ -868,6 +949,10 @@ const data2023 = [
     // Winner Pack Across Time --- wp9
     {
         "id": null,
+        "block": {
+            "0": ["P"],
+            "1": ["BT7"]
+        },
         "slug": "wp9",
         "name": "Winner Pack -Across Time-",
         "release": "Late April - July 2023",
@@ -885,6 +970,10 @@ const data2023 = [
     // Store Championship 2023 Participant Pack --- storechampion_2023_0
     {
         "id": null,
+        "block": {
+            "1": ["BT6","ST9","ST10"],
+            "1": ["BT10","BT11","ST13"]
+        },
         "slug": "storechampion_2023_0",
         "name": "Store Championship 2023 Participant Pack",
         "release": "June, 2023",
@@ -904,6 +993,10 @@ const data2023 = [
     // Store Championship 2023 Top 4 Pack --- storechampion_2023_1
     {
         "id": null,
+        "block": {
+            "1": ["BT6","ST9","ST10"],
+            "1": ["BT10","BT11","ST13"]
+        },
         "slug": "storechampion_2023_1",
         "name": "Store Championship 2023 Top 4 Pack",
         "release": "June, 2023",
@@ -922,6 +1015,7 @@ const data2023 = [
     // Store Championship 2023 Champion Card --- storechampion_2023_2
     {
         "id": null,
+        "block": 1,
         "slug": "storechampion_2023_2",
         "name": "Store Championship 2023 Champion Card",
         "release": "June, 2023",
@@ -934,6 +1028,10 @@ const data2023 = [
     // Tamer Party -Special- --- tp_special
     {
         "id": null,
+        "block": {
+            "1": ["BT8"],
+            "2": ["BT12"]
+        },
         "slug": "tp_special",
         "name": "Tamer Party -Special-",
         "release": "June, 2023",
@@ -952,6 +1050,7 @@ const data2023 = [
     // Booster Alternative Being [EX4] --- ex4
     {
         "id": "EX4",
+        "block": 2,
         "slug": "ex4",
         "name": "Booster Alternative Being [EX4]",
         "release": "June 23, 2023",
@@ -994,6 +1093,7 @@ const data2023 = [
     // Booster Alternative Being [EX4] - Alternatives --- ex4_alts
     {
         "id": null,
+        "block": 2,
         "slug": "ex4_alts",
         "name": "Booster Alternative Being [EX4] - Alternatives",
         "release": "June 23, 2023",
@@ -1021,6 +1121,7 @@ const data2023 = [
     },
     {
         "id": null,
+        "block": 0,
         "slug": "ex4_alts",
         "name": "Booster Alternative Being [EX4] - Alternatives",
         "release": "June 23, 2023",
@@ -1032,6 +1133,7 @@ const data2023 = [
     // Booster Alternative Being [EX4] - Box Topper --- ex4_boxtopper
     {
         "id": null,
+        "block": 2,
         "slug": "ex4_boxtopper",
         "name": "Booster Alternative Being [EX4] - Box Topper",
         "release": "June 23, 2023",
@@ -1053,6 +1155,7 @@ const data2023 = [
     // Royal Knights Binder Set [PB13] --- pb13
     {
         "id": null,
+        "block": 1,
         "slug": "pb13",
         "name": "Royal Knights Binder Set [PB13]",
         "release": "March, 2023",
@@ -1073,6 +1176,10 @@ const data2023 = [
     // Deck Box Set / Beelzemon --- deckbox
     {
         "id": null,
+        "block": {
+            "0": ["BT5-083"],
+            "1": ["BT3-057","BT5-044","BT6-017","BT6-065","EX2-045"]
+        },
         "slug": "deckbox",
         "name": "Deck Box Set / Beelzemon",
         "release": "June, 2023",
@@ -1091,6 +1198,7 @@ const data2023 = [
     // Tamer Goods Set Angewomon & LadyDevimon [PB14] --- pb14
     {
         "id": null,
+        "block": 1,
         "slug": "pb14",
         "name": "Tamer Goods Set Angewomon & LadyDevimon [PB14]",
         "release": "June, 2023",
@@ -1106,6 +1214,7 @@ const data2023 = [
     // Versus Royal Knights (BT13) Pre-Release Tournaments --- bt13_prerelease
     {
         "id": null,
+        "block": 2,
         "slug": "bt13_prerelease",
         "name": "Versus Royal Knights (BT13) Pre-Release Tournaments",
         "release": "April 21 - April 28, 2023",
@@ -1124,6 +1233,7 @@ const data2023 = [
     // Booster Versus Royal Knights [BT13] --- bt13
     {
         "id": "BT13",
+        "block": 2,
         "slug": "bt13",
         "name": "Versus Royal Knights [BT13]",
         "release": "July 21, 2023",
@@ -1159,6 +1269,7 @@ const data2023 = [
     // Booster Versus Royal Knights [BT13] - Alternatives --- bt13_alts
     {
         "id": null,
+        "block": 2,
         "slug": "bt13_alts",
         "name": "Versus Royal Knights [BT13] - Alternatives",
         "release": "July 21, 2023",
@@ -1195,6 +1306,7 @@ const data2023 = [
     // Booster Versus Royal Knights [BT13] - Box Topper --- bt13_boxtopper
     {
         "id": null,
+        "block": 2,
         "slug": "bt13_boxtopper",
         "name": "Versus Royal Knights [BT13] - Box Topper",
         "release": "July 21, 2023",
@@ -1212,6 +1324,7 @@ const data2023 = [
     // Starter Deck Dragon of Courage [ST15] --- st15
     {
         "id": "ST15",
+        "block": 3,
         "slug": "st15",
         "name": "Starter Deck Dragon of Courage [ST-15]",
         "release": "October, 2023",
@@ -1232,6 +1345,7 @@ const data2023 = [
     // Starter Deck Wolf of Friendship [ST16] --- st16
     {
         "id": "ST16",
+        "block": 3,
         "slug": "st16",
         "name": "Starter Deck Wolf of Friendship [ST-16]",
         "release": "October, 2023",
@@ -1252,6 +1366,7 @@ const data2023 = [
     // Booster Versus Royal Knights [BT13] - Ace Box Topper --- bt13_aceboxtopper
     {
         "id": null,
+        "block": 3,
         "slug": "bt13_aceboxtopper",
         "name": "Versus Royal Knights [BT13] - Ace Box Topper",
         "release": "July 21, 2023",
@@ -1266,6 +1381,7 @@ const data2023 = [
     // Official Tournament Pack Vol.10 --- otp10
     {
         "id": null,
+        "block": 2,
         "slug": "otp10",
         "name": "Official Tournament Pack Vol.10",
         "release": "Mid July - November 2023",
@@ -1284,6 +1400,7 @@ const data2023 = [
     // Winner Pack Royal Knights --- wp10
     {
         "id": null,
+        "block": 2,
         "slug": "wp10",
         "name": "Winner Pack -Royal Knights-",
         "release": "Mid July - November 2023",
@@ -1302,6 +1419,10 @@ const data2023 = [
     // Store Championship 2023 Participant Pack Wave 2 --- storechampion_2023_wave2_0
     {
         "id": null,
+        "block": {
+            "1": ["BT7","BT8","BT9"],
+            "2": ["EX3"]
+        },
         "slug": "storechampion_2023_wave2_0",
         "name": "Store Championship 2023 Participant Pack Wave 2",
         "release": "June, 2023",
@@ -1321,6 +1442,10 @@ const data2023 = [
     // Store Championship 2023 Top 4 Pack --- storechampion_2023_wave2_1
     {
         "id": null,
+        "block": {
+            "1": ["BT7","BT8","BT9"],
+            "2": ["EX3"]
+        },
         "slug": "storechampion_2023_wave2_1",
         "name": "Store Championship 2023 Top 4 Pack Wave 2",
         "release": "June, 2023",
@@ -1339,6 +1464,7 @@ const data2023 = [
     // Store Championship 2023 Champion Card --- storechampion_2023_wave2_2
     {
         "id": null,
+        "block": 1,
         "slug": "storechampion_2023_wave2_2",
         "name": "Store Championship 2023 Champion Card Wave 2",
         "release": "June, 2023",
@@ -1353,6 +1479,7 @@ const data2023 = [
     // Bandai Card Games Official Guide --- bandai_cgo_guide
     {
         "id": null,
+        "block": 2,
         "slug": "bandai_cgo_guide",
         "name": "Bandai Card Games Official Guide",
         "release": "3 August, 2023",
@@ -1365,6 +1492,11 @@ const data2023 = [
     // 2023 Regionals Participant Set 2 --- regional2023_2_0
     {
         "id": null,
+        "block": {
+            "0": ["BT1","BT3","BT4"],
+            "1": ["BT7"],
+            "2": ["BT10","BT11","EX3"]
+        },
         "slug": "regional2023_2_0",
         "name": "2023 Regionals Participant Set 2",
         "release": "July-September, 2023",
@@ -1383,6 +1515,11 @@ const data2023 = [
     // 2023 Regionals Finalist Set 2 --- regional2023_2_1
     {
         "id": null,
+        "block": {
+            "0": ["BT1","BT3","BT4"],
+            "1": ["BT7"],
+            "2": ["BT10","BT11","EX3"]
+        },
         "slug": "regional2023_2_1",
         "name": "2023 Regionals Finalist Set 2",
         "release": "July-September, 2023",
@@ -1401,6 +1538,11 @@ const data2023 = [
     // 2023 Regionals Champion Set 2 --- regional2023_2_2
     {
         "id": null,
+        "block": {
+            "0": ["BT1","BT3","BT4"],
+            "1": ["BT7"],
+            "2": ["BT10","BT11","EX3"]
+        },
         "slug": "regional2023_2_2",
         "name": "2023 Regionals Champion Set 2",
         "release": "July-September, 2023",
@@ -1419,6 +1561,11 @@ const data2023 = [
     // Event Pack 5 --- eventpack5
     {
         "id": null,
+        "block": {
+            "0": ["BT1","BT5"],
+            "1": ["BT6","BT8","BT9","EX2"],
+            "2": ["BT10","BT11"]
+        },
         "slug": "eventpack5",
         "name": "Event Pack 5",
         "release": "July-September, 2023",
@@ -1451,6 +1598,7 @@ const data2023 = [
     // Resurgence Booster [RB01] --- rb01
     {
         "id": "RB1",
+        "block": 2,
         "slug": "rb1",
         "name": "Resurgence Booster [RB01]",
         "release": "September 29, 2023",
@@ -1481,6 +1629,7 @@ const data2023 = [
     // Resurgence Booster [RB01] - Alternatives --- rb1_alts
     {
         "id": null,
+        "block": 2,
         "slug": "rb1_alts",
         "name": "Resurgence Booster [RB01] - Alternatives",
         "release": "September 29, 2023",
@@ -1498,6 +1647,7 @@ const data2023 = [
     // Resurgence Booster [RB01] - Box Topper --- rb1_boxtopper
     {
         "id": null,
+        "block": 2,
         "slug": "rb1_boxtopper",
         "name": "Resurgence Booster [RB01] - Box Topper",
         "release": "September 29, 2023",
@@ -1643,6 +1793,7 @@ const data2023 = [
             }
         },
         "reprint": true,
+        "block": 2,
     },
     // Resurgence Booster [RB01] - English Reprints --- rb1_en_reprints
     {
@@ -1665,10 +1816,12 @@ const data2023 = [
             "ST3": "c"
         },
         "reprint": true,
+        "block": 2,
     },
     // TODO: Revise this cards in localstorage.
     {
         "id": null,
+        "block": 2,
         "slug": "rb1_en_reprints",
         "name": "Resurgence Booster [RB01] - English Reprints",
         "release": "September 29, 2023",
@@ -1684,6 +1837,7 @@ const data2023 = [
     // Adventure Box 2 [AB02] --- ab02
     {
         "id": null,
+        "block": 2,
         "slug": "ab02",
         "name": "Adventure Box 2 [AB02]",
         "release": "September, 2023",
@@ -1703,6 +1857,10 @@ const data2023 = [
     // Starter Deck ST15 & ST16 Pre-Release Tournament --- st15st16_prerelease
     {
         "id": null,
+        "block": {
+            "1": ["BT9"],
+            "2": ["BT5"]
+        },
         "slug": "st15st16_prerelease",
         "name": "Starter Deck ST15 & ST16 Pre-Release Tournament",
         "release": "October 6 – 12, 2023",
@@ -1713,13 +1871,14 @@ const data2023 = [
         ],
         "cards": {
             "BT9-020": "P2",
-            "BT5-087": "P4",
+            "BT5-087": "P5",
         },
         "info_url": "https://world.digimoncard.com/event/pre-release_ST15-ST16/",
     },
     // Starter Deck Dragon of Courage [ST15] - Alternatives --- st15_alts
     {
         "id": null,
+        "block": 3,
         "slug": "st15_alts",
         "name": "Starter Deck Dragon of Courage [ST15] - Alternatives",
         "release": "October, 2023",
@@ -1731,6 +1890,7 @@ const data2023 = [
     // Starter Deck Wolf of Friendship [ST16] - Alternatives --- st16_alts
     {
         "id": null,
+        "block": 3,
         "slug": "st16_alts",
         "name": "Starter Deck Wolf of Friendship [ST16] - Alternatives",
         "release": "October, 2023",
@@ -1742,6 +1902,7 @@ const data2023 = [
     // 2023 Regionals Participant Set 3 --- regional2023_3_0
     {
         "id": null,
+        "block": 2,
         "slug": "regional2023_3_0",
         "name": "2023 Regionals Participant Set 3",
         "release": "October, 2023",
@@ -1760,6 +1921,7 @@ const data2023 = [
     // 2023 Regionals Finalist Set 3 --- regional2023_3_1
     {
         "id": null,
+        "block": 2,
         "slug": "regional2023_3_1",
         "name": "2023 Regionals Finalist Set 3",
         "release": "October, 2023",
@@ -1778,6 +1940,7 @@ const data2023 = [
     // 2023 Regionals Champion Set 3 --- regional2023_3_2
     {
         "id": null,
+        "block": 2,
         "slug": "regional2023_3_2",
         "name": "2023 Regionals Champion Set 3",
         "release": "October, 2023",
@@ -1796,6 +1959,11 @@ const data2023 = [
     // Judge Pack 4 --- judgepack4
     {
         "id": null,
+        "block": {
+            "0": ["BT1","BT5"],
+            "1": ["BT7"],
+            "2": ["EX4","P","ST14"]
+        },
         "slug": "judgepack4",
         "name": "Judge Pack 4",
         "release": "October, 2023",
@@ -1818,6 +1986,7 @@ const data2023 = [
     // Booster Blast Ace (BT14) Pre-Release Tournaments --- bt14_prerelease
     {
         "id": null,
+        "block": 3,
         "slug": "bt14_prerelease",
         "name": "Booster Blast Ace (BT14) Pre-Release Tournaments",
         "release": "November 10 - 16, 2023",
@@ -1833,6 +2002,10 @@ const data2023 = [
     // Tamer Party -THE BEGINNING- ver.1.0 --- tp_beginning
     {
         "id": null,
+        "block": {
+            "0": ["BT3","BT5"],
+            "1": ["BT8","ST9"]
+        },
         "slug": "tp_beginning",
         "name": "Tamer Party -THE BEGINNING- ver.1.0",
         "release": "November, 2023",
@@ -1858,6 +2031,7 @@ const data2023 = [
     // Double Pack Set [DP-01] --- dp01
     {
         "id": null,
+        "block": 1,
         "slug": "dp01",
         "name": "Double Pack Set [DP-01]",
         "release": "November 17, 2023",
@@ -1876,6 +2050,10 @@ const data2023 = [
     // Gift Box 2023 [GB03] --- gb03
     {
         "id": null,
+        "block": {
+            "0": ["BT3"],
+            "3": ["ST15","ST16"]
+        },
         "slug": "gb03",
         "name": "Gift Box 2023 [GB03]",
         "release": "November 17, 2023",
@@ -1892,6 +2070,7 @@ const data2023 = [
     // Booster Blast Ace [BT14] --- bt14
     {
         "id": "BT14",
+        "block": 3,
         "slug": "bt14",
         "name": "Booster Blast Ace [BT14]",
         "release": "November 17, 2023",
@@ -1926,6 +2105,7 @@ const data2023 = [
     // Booster Blast Ace [BT14] - Alternatives --- bt14_alts
     {
         "id": null,
+        "block": 3,
         "slug": "bt14_alts",
         "name": "Booster Blast Ace [BT14] - Alternatives",
         "release": "November 17, 2023",
@@ -1956,6 +2136,7 @@ const data2023 = [
     // Booster Blast Ace [BT14] - English Alternatives --- bt14_en_alts
     {
         "id": null,
+        "block": 3,
         "slug": "bt14_en_alts",
         "name": "Booster Blast Ace [BT14] - English Alternatives",
         "release": "November 17, 2023",
@@ -1970,6 +2151,7 @@ const data2023 = [
     // TODO: Esta carta es una SP.
     {
         "id": null,
+        "block": 1,
         "slug": "bt14_en_alts",
         "name": "Booster Blast Ace [BT14] - English Alternatives",
         "release": "November 17, 2023",
@@ -1981,6 +2163,7 @@ const data2023 = [
     // Booster Blast Ace [BT14] - Box Topper --- bt14_boxtopper
     {
         "id": null,
+        "block": 3,
         "slug": "bt14_boxtopper",
         "name": "Booster Blast Ace [BT14] - Box Topper",
         "release": "November 17, 2023",
@@ -1997,6 +2180,7 @@ const data2023 = [
     // Booster Blast Ace [BT14] - Limited Card Set --- bt14_en_boxtopper
     {
         "id": null,
+        "block": 2,
         "slug": "bt14_en_boxtopper",
         "name": "Booster Blast Ace [BT14] - Limited Card Set",
         "release": "November 17, 2023",
@@ -2014,6 +2198,7 @@ const data2023 = [
     // Booster Blast Ace [BT14] - Survey Pack --- bt14_survey_pack
     {
         "id": null,
+        "block": 3,
         "slug": "bt14_survey_pack",
         "name": "Booster Blast Ace [BT14] - Survey Pack",
         "release": "November 17, 2023",
@@ -2031,6 +2216,12 @@ const data2023 = [
     // Demo Deck: Imperialdramon --- demo_deck_imperialdramon
     {
         "id": null,
+        "block": {
+            "0": ["BT3"],
+            "1": ["ST9"],
+            "2": ["BT12","P-036"],
+            "3": ["P-109","P-117","P-123","P-124","P-130"]
+        },
         "slug": "demo_deck_imperialdramon",
         "name": "Demo Deck: Imperialdramon",
         "release": "November 17, 2023",
@@ -2063,6 +2254,7 @@ const data2023 = [
     // 3 on 3 Battle - Participation Prize --- 3on3_battle_participation
     {
         "id": null,
+        "block": 2,
         "slug": "3on3_battle_participation",
         "name": "3 on 3 Battle - Participation Prize",
         "release": "November",
@@ -2076,6 +2268,10 @@ const data2023 = [
     // 3on3 Battle - Top 4 --- 3on3_battle_top4
     {
         "id": null,
+        "block": {
+            "1": ["BT8"],
+            "2": ["ST14"]
+        },
         "slug": "3on3_battle_top4",
         "name": "3 on 3 Battle - Top 4",
         "release": "November",
@@ -2089,6 +2285,10 @@ const data2023 = [
     // 3on3 Battle - 1st Place --- 3on3_battle_1st
     {
         "id": null,
+        "block": {
+            "1": ["BT8"],
+            "2": ["ST14"]
+        },
         "slug": "3on3_battle_1st",
         "name": "3 on 3 Battle - 1st Place",
         "release": "November",
@@ -2103,6 +2303,7 @@ const data2023 = [
     // Official Tournament Pack Vol.11 --- otp11
     {
         "id": null,
+        "block": 3,
         "slug": "otp11",
         "name": "Official Tournament Pack Vol.11",
         "release": "Mid November - February 2024",
@@ -2127,6 +2328,7 @@ const data2023 = [
     // Winner Pack Blast Ace --- wp11
     {
         "id": null,
+        "block": 3,
         "slug": "wp11",
         "name": "Winner Pack -Blast Ace-",
         "release": "Mid November - February 2024",
@@ -2145,6 +2347,7 @@ const data2023 = [
     // Tamer Party -THE BEGINNING- ver.2.0 --- tp_beginning_2
     {
         "id": null,
+        "block": 3,
         "slug": "tp_beginning_2",
         "name": "Tamer Party -THE BEGINNING- ver.2.0",
         "release": "December, 2023",
@@ -2176,6 +2379,11 @@ const data2023 = [
     // Winter Holiday Event --- whe
     {
         "id": null,
+        "block": {
+            "0": ["ST3"],
+            "1": ["EX1"],
+            "3": ["ST15","ST16"]
+        },
         "slug": "whe",
         "name": "Winter Holiday Event",
         "release": "December 1, 2023 – January 31, 2024",
@@ -2192,6 +2400,10 @@ const data2023 = [
     // 2023 Championship Finals Tamers Pack --- tamerpack_2023
     {
         "id": null,
+        "block": {
+            "2": ["BT10","BT11","BT12","BT13"],
+            "3": ["BT14"]
+        },
         "slug": "tamerpack_2023",
         "name": "2023 Championship Finals Tamers Pack",
         "release": "December 2 - 3, 2023",
@@ -2221,6 +2433,7 @@ const data2023 = [
     // 2023 Championship Finals Gold Card Set --- goldcardset_2023
     {
         "id": null,
+        "block": 1,
         "slug": "goldcardset_2023",
         "name": "2023 Championship Finals Gold Card Set",
         "release": "December 2 - 3, 2023",
@@ -2238,6 +2451,7 @@ const data2023 = [
     // 2023 Championship Finals Trophy Cards - Top 16 --- cftc_2023_top16
     {
         "id": null,
+        "block": 2,
         "slug": "cftc_2023_top16",
         "name": "2023 Championship Finals Framed Trophy Cards - Top 16",
         "release": "December 2 - 3, 2023",
@@ -2250,6 +2464,7 @@ const data2023 = [
     // 2023 Championship Finals Trophy Cards - 3rd & 4th Place --- cftc_2023_top3&4
     {
         "id": null,
+        "block": 2,
         "slug": "cftc_2023_top3&4",
         "name": "2023 Championship Finals Framed Trophy Cards - 3rd & 4th Place",
         "release": "December 2 - 3, 2023",
@@ -2262,6 +2477,7 @@ const data2023 = [
     // 2023 Championship Finals Trophy Cards - 2nd Place --- cftc_2023_top2
     {
         "id": null,
+        "block": 2,
         "slug": "cftc_2023_top2",
         "name": "2023 Championship Finals Framed Trophy Cards - 2nd Place",
         "release": "December 2 - 3, 2023",
@@ -2274,6 +2490,7 @@ const data2023 = [
     // 2023 Championship Finals Trophy Cards - 1st Place --- cftc_2023_top1
     {
         "id": null,
+        "block": 2,
         "slug": "cftc_2023_top1",
         "name": "2023 Championship Finals Framed Trophy Cards - 1st Place",
         "release": "December 2 - 3, 2023",

--- a/js/data/data_2024.js
+++ b/js/data/data_2024.js
@@ -2051,7 +2051,7 @@ const data2024 = [
         "id": null,
         "block": {
             "2": ["BT10","P"],
-            "4": ["BT16","EX6","ST17"]
+            "3": ["BT16","EX6","ST17"]
         },
         "slug": "regional2024_3_0",
         "name": "2024 Regionals Participant Card Set Wave 3",
@@ -2073,7 +2073,7 @@ const data2024 = [
         "id": null,
         "block": {
             "2": ["BT10","P"],
-            "4": ["BT16","EX6","ST17"]
+            "3": ["BT16","EX6","ST17"]
         },
         "slug": "regional2024_3_1",
         "name": "2024 Regionals Finalist Card Set Wave 3",
@@ -2095,7 +2095,7 @@ const data2024 = [
         "id": null,
         "block": {
             "2": ["BT10","P"],
-            "4": ["BT16","EX6","ST17"]
+            "3": ["BT16","EX6","ST17"]
         },
         "slug": "regional2024_3_2",
         "name": "2024 Regionals Champion Card Set Wave 3",

--- a/js/data/data_2024.js
+++ b/js/data/data_2024.js
@@ -3,6 +3,7 @@ const data2024 = [
     // Booster Animal Colusseum [EX5] --- ex5
     {
         "id": "EX5",
+        "block": 3,
         "slug": "ex5",
         "name": "Booster Animal Colusseum [EX5]",
         "release": "January 19, 2024",
@@ -45,6 +46,7 @@ const data2024 = [
     // Booster Animal Colusseum [EX5] - Alternatives --- ex5_alts
     {
         "id": null,
+        "block": 3,
         "slug": "ex5_alts",
         "name": "Booster Animal Colusseum [EX5] - Alternatives",
         "release": "January 19, 2024",
@@ -75,6 +77,7 @@ const data2024 = [
     // Booster Animal Colusseum [EX5] - Box Topper --- ex5_boxtopper
     {
         "id": null,
+        "block": 3,
         "slug": "ex5_boxtopper",
         "name": "Booster Animal Colusseum [EX5] - Box Topper",
         "release": "January 19, 2024",
@@ -93,6 +96,7 @@ const data2024 = [
     // Booster Animal Colusseum [EX5] - Limited Card Set ver.2 --- ex5_limited_2
     {
         "id": null,
+        "block": 2,
         "slug": "ex5_limited_2",
         "name": "Booster Animal Colusseum [EX5] - Limited Card Set ver.2",
         "release": "January 19, 2024",
@@ -111,6 +115,7 @@ const data2024 = [
     // Booster Animal Colusseum [EX5] - 3rd Anniversary Update Pack --- ex5_update_pack_3
     {
         "id": null,
+        "block": 2,
         "slug": "ex5_update_pack_3",
         "name": "Booster Animal Colusseum [EX5] - 3rd Anniversary Update Pack",
         "release": "January 19, 2024",
@@ -131,6 +136,7 @@ const data2024 = [
     // Bandai Card Games Fest 23-34 World Tour --- bcg_fest_23_24
     {
         "id": null,
+        "block": 3,
         "slug": "bcg_fest_23_24",
         "name": "Bandai Card Games Fest 23-34 World Tour",
         "release": "January 27, 2024",
@@ -144,6 +150,7 @@ const data2024 = [
     // Digimon Liberator Promotion Pack --- liberator_pack
     {
         "id": null,
+        "block": 4,
         "slug": "liberator_pack",
         "name": "Digimon Liberator Promotion Pack",
         "release": "January 27, 2024",
@@ -163,6 +170,11 @@ const data2024 = [
     // Digimon Illustration Competition Pack 2023 --- ilustration_pack_2023
     {
         "id": null,
+        "block": {
+            "0": ["BT2","BT3"],
+            "1": ["BT9","EX1","ST9","P"],
+            "2": ["BT10"],
+        },
         "slug": "ilustration_pack_2023",
         "name": "Digimon Illustration Competition Pack 2023",
         "release": "January 27, 2024",
@@ -185,6 +197,10 @@ const data2024 = [
     // Premium Binder Set --- premium_binder_set
     {
         "id": null,
+        "block": {
+            "1": ["BT6","BT7"],
+            "2": ["BT12","EX2"]
+        },
         "slug": "premium_binder_set",
         "name": "Premium Binder Set",
         "release": "February, 2024",
@@ -201,6 +217,10 @@ const data2024 = [
     // Tamer Goods Set Diaboromon [PB16] --- pb16
     {
         "id": null,
+        "block": {
+            "0": ["BT2","BT5"],
+            "3": ["P"]
+        },
         "slug": "pb16",
         "name": "Tamer Goods Set Diaboromon [PB16]",
         "release": "February, 2024",
@@ -222,6 +242,10 @@ const data2024 = [
     // Booster Exceed Apocalypse (BT15) Pre-Release Tournaments --- bt15_prerelease
     {
         "id": null,
+        "block": {
+            "2": ["P"],
+            "3": ["BT10"]
+        },
         "slug": "bt15_prerelease",
         "name": "Booster Exceed Apocalypse (BT15) Pre-Release Tournaments",
         "release": "February 9 - 15, 2024",
@@ -241,6 +265,7 @@ const data2024 = [
     // Booster Exceed Apocalypse [BT15] --- bt15
     {
         "id": "BT15",
+        "block": 3,
         "slug": "bt15",
         "name": "Booster Exceed Apocalypse [BT15]",
         "release": "February 16, 2024",
@@ -279,6 +304,7 @@ const data2024 = [
     // Booster Exceed Apocalypse [BT15] - Alternatives --- bt15_alts
     {
         "id": null,
+        "block": 3,
         "slug": "bt15_alts",
         "name": "Booster Exceed Apocalypse [BT15] - Alternatives",
         "release": "February 16, 2024",
@@ -309,6 +335,7 @@ const data2024 = [
     // Booster Exceed Apocalypse [BT15] - Rare Foil Cards --- bt15_rare_foil
     {
         "id": null,
+        "block": 3,
         "slug": "bt15_rare_foil",
         "name": "Booster Exceed Apocalypse [BT15] - Rare Foil Cards",
         "release": "February 16, 2024",
@@ -328,6 +355,7 @@ const data2024 = [
     // Booster Exceed Apocalypse [BT15] - Box Topper --- bt15_boxtopper
     {
         "id": null,
+        "block": 3,
         "slug": "bt15_boxtopper",
         "name": "Booster Exceed Apocalypse [BT15] - Box Topper",
         "release": "February 16, 2024",
@@ -341,6 +369,7 @@ const data2024 = [
             "BT15-006": "P",
         },
     },
+    // TODO: Mover a data_norelease.js
     // Limited Pack [LM]
     {
         "id": "LM",
@@ -387,6 +416,7 @@ const data2024 = [
     // Limited Pack Digimon Ghost Game [LM01] --- lm01
     {
         "id": null,
+        "block": 3,
         "slug": "lm01",
         "name": "Limited Pack Digimon Ghost Game [LM01]",
         "release": "February 16, 2024",
@@ -426,6 +456,10 @@ const data2024 = [
     // Double Pack Set [DP-02] --- dp02
     {
         "id": null,
+        "block": {
+            "1": ["BT8","BT9"],
+            "2": ["BT10"],
+        },
         "slug": "dp02",
         "name": "Double Pack Set [DP-02]",
         "release": "November 17, 2023",
@@ -445,6 +479,11 @@ const data2024 = [
     // Official Tournament Pack Vol.12 --- otp12
     {
         "id": null,
+        "block": {
+            "0": ["BT4"],
+            "1": ["BT6","BT8","EX1"],
+            "3": ["BT11","EX3"],
+        },
         "slug": "otp12",
         "name": "Official Tournament Pack Vol.12",
         "release": "Mid February - May 2024",
@@ -463,6 +502,7 @@ const data2024 = [
     // Winner Pack Exceed Apocalypse --- wp12
     {
         "id": null,
+        "block": 3,
         "slug": "wp12",
         "name": "Winner Pack -Exceed Apocalypse-",
         "release": "Mid February - May 2024",
@@ -481,6 +521,10 @@ const data2024 = [
     // Ultimate Cup 2024 --- ultimatecup_2024
     {
         "id": null,
+        "block": {
+            "1": ["BT7","EX2"],
+            "2": ["BT12"]
+        },
         "slug": "ultimatecup_2024",
         "name": "Ultimate Cup 2024",
         "release": "February-August, 2024",
@@ -500,6 +544,10 @@ const data2024 = [
     // Event Pack 6 --- eventpack6
     {
         "id": null,
+        "block": {
+            "1": ["BT9"],
+            "2": ["BT10","BT11","BT12","BT13","RB1"]
+        },
         "slug": "eventpack6",
         "name": "Event Pack 6",
         "release": "February-August, 2024",
@@ -516,6 +564,7 @@ const data2024 = [
     },
     {
         "id": null,
+        "block": 2,
         "slug": "eventpack6",
         "name": "Event Pack 6",
         "release": "February-August, 2024",
@@ -529,6 +578,10 @@ const data2024 = [
     // Judge Pack 5 --- judgepack5
     {
         "id": null,
+        "block": {
+            "1": ["BT9"],
+            "2": ["BT10","BT11","BT12","BT13","ST12"]
+        },
         "slug": "judgepack5",
         "name": "Judge Pack 5",
         "release": "February-August, 2024",
@@ -552,6 +605,10 @@ const data2024 = [
     // Advanced Deck DOUBLE TYPHOON [ST17] Pre-Release DOUBLE TYPHOON CUP --- st17_prerelease
     {
         "id": null,
+        "block": {
+            "1": ["BT8"],
+            "2": ["BT3"],
+        },
         "slug": "st17_prerelease",
         "name": "Advanced Deck DOUBLE TYPHOON [ST17] Pre-Release DOUBLE TYPHOON CUP",
         "release": "March 1 – 7, 2024",
@@ -568,6 +625,7 @@ const data2024 = [
     // 2023 World Championship - Participation --- wc2023
     {
         "id": null,
+        "block": 2,
         "slug": "wc2023",
         "name": "2023 World Championship - Participation",
         "release": "March 3, 2024",
@@ -581,6 +639,7 @@ const data2024 = [
     // 2023 World Championship 3rd & 4th Place --- wc2023_3rd_4th
     {
         "id": null,
+        "block": 2,
         "slug": "wc2023_3rd_4th",
         "name": "2023 World Championship - 3rd & 4th Place",
         "release": "March 3, 2024",
@@ -593,6 +652,7 @@ const data2024 = [
     // 2023 World Championship 2nd Place --- wc2023_2nd
     {
         "id": null,
+        "block": 2,
         "slug": "wc2023_2nd",
         "name": "2023 World Championship - 2nd Place",
         "release": "March 3, 2024",
@@ -605,6 +665,7 @@ const data2024 = [
     // 2023 World Championship 1st Place --- wc2023_1st
     {
         "id": null,
+        "block": 2,
         "slug": "wc2023_1st",
         "name": "2023 World Championship - 1st Place",
         "release": "March 3, 2024",
@@ -619,6 +680,7 @@ const data2024 = [
     // Advanced Deck DOUBLE TYPHOON [ST17] --- st17
     {
         "id": "ST17",
+        "block": 3,
         "slug": "st17",
         "name": "Advanced Deck DOUBLE TYPHOON [ST17]",
         "release": "March 8, 2024",
@@ -649,6 +711,7 @@ const data2024 = [
     // Advanced Deck DOUBLE TYPHOON [ST17] - Alternatives --- st17_alts
     {
         "id": null,
+        "block": 3,
         "slug": "st17_alts",
         "name": "Advanced Deck DOUBLE TYPHOON [ST17] - Alternatives",
         "release": "March 8, 2024",
@@ -666,6 +729,7 @@ const data2024 = [
     // Advanced Deck DOUBLE TYPHOON [ST17] - Secret Pack --- st17_secretpack
     {
         "id": null,
+        "block": 3,
         "slug": "st17_secretpack",
         "name": "Advanced Deck DOUBLE TYPHOON [ST17] - Secret Pack",
         "release": "March 8, 2024",
@@ -685,6 +749,8 @@ const data2024 = [
         "id": null,
         "slug": "st17_reprints",
         "name": "Advanced Deck DOUBLE TYPHOON [ST17] - Reprints",
+        "reprint": true,
+        "block": 3,
         "release": "March 8, 2024",
         "url": "bandaitcgplusURL/ST17/e_setID-cardIDparallel_D.png",
         "cards": {
@@ -704,6 +770,10 @@ const data2024 = [
     // Spring Break Event --- spring_break
     {
         "id": null,
+        "block": {
+            "2": ["EX4-063"],
+            "3": ["EX4-032","EX4-034"]
+        },
         "slug": "spring_break",
         "name": "Spring Break Event",
         "release": "March 8 - April 30, 2024",
@@ -717,6 +787,7 @@ const data2024 = [
     },
     {
         "id": null,
+        "block": 3,
         "slug": "spring_break",
         "name": "Spring Break Event",
         "release": "March 8 - April 30, 2024",
@@ -731,6 +802,7 @@ const data2024 = [
     // 2024 Regionals Participation Card Set Wave 1 --- regional2024_1_0
     {
         "id": null,
+        "block": 3,
         "slug": "regional2024_1_0",
         "name": "2024 Regionals Participant Card Set Wave 1",
         "release": "March-May, 2024",
@@ -749,6 +821,7 @@ const data2024 = [
     // 2024 Regionals Finalist Card Set Wave 1 --- regional2024_1_1
     {
         "id": null,
+        "block": 3,
         "slug": "regional2024_1_1",
         "name": "2024 Regionals Finalist Card Set Wave 1",
         "release": "March-May, 2024",
@@ -767,6 +840,7 @@ const data2024 = [
     // 2024 Regionals Champion Card Set Wave 1 --- regional2024_1_2
     {
         "id": null,
+        "block": 3,
         "slug": "regional2024_1_2",
         "name": "2024 Regionals Champion Card Set Wave 1",
         "release": "March-May, 2024",
@@ -785,6 +859,7 @@ const data2024 = [
     // 2024 Serial Number Card --- serial_number_2024
     {
         "id": null,
+        "block": 2,
         "slug": "serial_number_2024",
         "name": "2024 Serial Number Card",
         "release": "March-May, 2024",
@@ -799,6 +874,7 @@ const data2024 = [
     // D-3 Ver.Davis Motomiya / Ken Ichijoji - d3davisken
     {
         "id": null,
+        "block": 1,
         "slug": "d3davisken",
         "name": "D-3 Ver.Davis Motomiya / Ken Ichijoji",
         "release": "May, 2024",
@@ -811,6 +887,7 @@ const data2024 = [
     // Official Tournament Pack Vol.13 --- otp13
     {
         "id": null,
+        "block": 2,
         "slug": "otp13",
         "name": "Official Tournament Pack Vol.13",
         "release": "May – June 2024",
@@ -825,6 +902,7 @@ const data2024 = [
     },
     {
         "id": null,
+        "block": 2,
         "slug": "otp13",
         "name": "Official Tournament Pack Vol.13",
         "release": "May – June 2024",
@@ -841,6 +919,7 @@ const data2024 = [
     // Official Tournament Pack Vol.13 - Winner Pack --- wp13
     {
         "id": null,
+        "block": 3,
         "slug": "wp13",
         "name": "Official Tournament Pack Vol.13 - Winner Pack",
         "release": "May – June 2024",
@@ -859,6 +938,11 @@ const data2024 = [
     // Evolution Cup May 2024 Participant Pack --- evolution_cup_participant
     {
         "id": null,
+        "block": {
+            "1": ["BT8"],
+            "2": ["BT13","EX4"],
+            "4": ["P"]
+        },
         "slug": "evolution_cup_participant",
         "name": "Evolution Cup May 2024 Participant Pack",
         "release": "May 10 – June 3, 2024",
@@ -881,6 +965,11 @@ const data2024 = [
     // Evolution Cup May 2024 Top 4 Pack --- evolution_cup_top4
     {
         "id": null,
+        "block": {
+            "1": ["BT8"],
+            "2": ["BT13","EX4"],
+            "4": ["P"]
+        },
         "slug": "evolution_cup_top4",
         "name": "Evolution Cup May 2024 Top 4 Pack",
         "release": "May 10 – June 3, 2024",
@@ -902,6 +991,7 @@ const data2024 = [
     // Evolution Cup May 2024 Champion Card --- evolution_cup_champion
     {
         "id": null,
+        "block": 2,
         "slug": "evolution_cup_champion",
         "name": "Evolution Cup May 2024 Champion Card",
         "release": "May 10 – June 3, 2024",
@@ -916,6 +1006,7 @@ const data2024 = [
     // Booster Beginning Observer (BT16) Pre-Release Tournaments --- bt16_prerelease
     {
         "id": null,
+        "block": 3,
         "slug": "bt16_prerelease",
         "name": "Booster Beginning Observer (BT16) Pre-Release Tournaments",
         "release": "May 17 - 23, 2024",
@@ -932,6 +1023,7 @@ const data2024 = [
     // Booster Beginning Observer [BT16] --- bt16
     {
         "id": "BT16",
+        "block": 3,
         "slug": "bt16",
         "name": "Booster Beginning Observer [BT16]",
         "release": "May 24, 2024",
@@ -980,6 +1072,7 @@ const data2024 = [
     // Booster Beginning Observer [BT16] - Alternatives --- bt16_alts
     {
         "id": null,
+        "block": 3,
         "slug": "bt16_alts",
         "name": "Booster Beginning Observer [BT16] - Alternatives",
         "release": "May 24, 2024",
@@ -1012,6 +1105,7 @@ const data2024 = [
     // Booster Beginning Observer [BT16] - Special SP Cards --- bt16_special_sp
     {
         "id": null,
+        "block": 3,
         "slug": "bt16_special_sp",
         "name": "Booster Beginning Observer [BT16] - Special SP Cards",
         "release": "May 24, 2024",
@@ -1031,6 +1125,7 @@ const data2024 = [
     // Booster Beginning Observer [BT16] - Special Design Alt --- bt16_special_design
     {
         "id": null,
+        "block": 3,
         "slug": "bt16_special_design",
         "name": "Booster Beginning Observer [BT16] - Special Design Alt",
         "release": "May 24, 2024",
@@ -1044,6 +1139,7 @@ const data2024 = [
     // Booster Beginning Observer [BT16] - Box Topper --- bt16_boxtopper
     {
         "id": null,
+        "block": 3,
         "slug": "bt16_boxtopper",
         "name": "Booster Beginning Observer [BT16] - Box Topper",
         "release": "May 24, 2024",
@@ -1062,6 +1158,7 @@ const data2024 = [
     // Adventure Box 3 [AB03] --- ab03
     {
         "id": null,
+        "block": 3,
         "slug": "ab03",
         "name": "Adventure Box 3 [AB03]",
         "release": "May 24, 2024",
@@ -1081,6 +1178,7 @@ const data2024 = [
     // "Digimon Adventure 02: The Beginning" Set [PB17] --- pb17
     {
         "id": null,
+        "block": 3,
         "slug": "pb17",
         "name": "\"Digimon Adventure 02: The Beginning\" Set [PB17]",
         "release": "June, 2024",
@@ -1107,6 +1205,7 @@ const data2024 = [
     // Digivice 25th Color Evolution Anniversary --- digivice25color
     {
         "id": null,
+        "block": 4,
         "slug": "digivice25color",
         "name": "Digivice 25th Color Evolution Anniversary",
         "release": "June, 2024",
@@ -1121,6 +1220,7 @@ const data2024 = [
     // Booster Infernal Ascension [EX6] --- ex6
     {
         "id": "EX6",
+        "block": 3,
         "slug": "ex6",
         "name": "Booster Infernal Ascension [EX6]",
         "release": "June 28, 2024",
@@ -1174,6 +1274,7 @@ const data2024 = [
     // Booster Infernal Ascension [EX6] - Alternatives --- ex6_alts
     {
         "id": null,
+        "block": 3,
         "slug": "ex6_alts",
         "name": "Booster Infernal Ascension [EX6] - Alternatives",
         "release": "June 28, 2024",
@@ -1205,6 +1306,7 @@ const data2024 = [
     // Booster Infernal Ascension [EX6] - Premium Special Design Alt --- ex6_special_design
     {
         "id": null,
+        "block": 3,
         "slug": "ex6_special_design",
         "name": "Booster Infernal Ascension [EX6] - Premium Special Design Alt",
         "release": "June 28, 2024",
@@ -1226,6 +1328,7 @@ const data2024 = [
     // Booster Infernal Ascension [EX6] - Box Topper --- ex6_boxtopper
     {
         "id": null,
+        "block": 3,
         "slug": "ex6_boxtopper",
         "name": "Booster Infernal Ascension [EX6] - Box Topper",
         "release": "June 28, 2024",
@@ -1240,6 +1343,7 @@ const data2024 = [
     },
     {
         "id": null,
+        "block": 3,
         "slug": "ex6_boxtopper",
         "name": "Booster Infernal Ascension [EX6] - Box Topper",
         "release": "June 28, 2024",
@@ -1255,6 +1359,10 @@ const data2024 = [
     // 2024 Regionals Participation Card Set Wave 2 --- regional2024_2_0
     {
         "id": null,
+        "block": {
+            "2": ["BT11","EX4"],
+            "3": ["BT14","BT15"]
+        },
         "slug": "regional2024_2_0",
         "name": "2024 Regionals Participant Card Set Wave 2",
         "release": "June-August, 2024",
@@ -1273,6 +1381,10 @@ const data2024 = [
     // 2024 Regionals Finalist Card Set Wave 2 --- regional2024_2_1
     {
         "id": null,
+        "block": {
+            "2": ["BT11","EX4"],
+            "3": ["BT14","BT15"]
+        },
         "slug": "regional2024_2_1",
         "name": "2024 Regionals Finalist Card Set Wave 2",
         "release": "June-August, 2024",
@@ -1291,6 +1403,10 @@ const data2024 = [
     // 2024 Regionals Champion Card Set Wave 2 --- regional2024_2_2
     {
         "id": null,
+        "block": {
+            "2": ["BT11","EX4"],
+            "3": ["BT14","BT15"]
+        },
         "slug": "regional2024_2_2",
         "name": "2024 Regionals Champion Card Set Wave 2",
         "release": "June-August, 2024",
@@ -1311,6 +1427,7 @@ const data2024 = [
     // Store Tournament 2024 Jul.-Sep. - Participation Pack --- otp14
     {
         "id": null,
+        "block": 4,
         "slug": "otp14",
         "name": "Store Tournament 2024 Jul.-Sep. - Participation Pack",
         "release": "July 1 - September 30, 2024",
@@ -1331,6 +1448,7 @@ const data2024 = [
     // Store Tournament 2024 Jul.-Sep. - Winner Pack --- wp14
     {
         "id": null,
+        "block": 4,
         "slug": "wp14",
         "name": "Store Tournament 2024 Jul.-Sep. - Winner Pack",
         "release": "July 1 - September 30, 2024",
@@ -1351,6 +1469,7 @@ const data2024 = [
     // DIGIMON LIBERATOR Promotion Campaign --- digimon_liberator_promo_camp
     {
         "id": null,
+        "block": 4,
         "slug": "digimon_liberator_promo_camp",
         "name": "DIGIMON LIBERATOR Promotion Campaign",
         "release": "July, 2024",
@@ -1367,6 +1486,7 @@ const data2024 = [
     // Gen Con 2024 --- gen_con_2024
     {
         "id": null,
+        "block": 2,
         "slug": "gen_con_2024",
         "name": "Gen Con 2024",
         "release": "August 1 - 4, 2024",
@@ -1381,6 +1501,7 @@ const data2024 = [
     // Booster Secret Crisis (BT17) Pre-Release Tournaments --- bt17_prerelease
     {
         "id": null,
+        "block": 2,
         "slug": "bt17_prerelease",
         "name": "Booster Secret Crisis (BT17) Pre-Release Tournaments",
         "release": "August 2 – 8, 2024",
@@ -1396,6 +1517,7 @@ const data2024 = [
     // Booster Secret Crysis [BT17] --- bt17
     {
         "id": "BT17",
+        "block": 3,
         "slug": "bt17",
         "name": "Booster Secret Crysis [BT17]",
         "release": "August 9, 2024",
@@ -1440,6 +1562,7 @@ const data2024 = [
     // Booster Secret Crysis [BT17] - Alternatives --- bt17_alts
     {
         "id": null,
+        "block": 3,
         "slug": "bt17_alts",
         "name": "Booster Secret Crysis [BT17] - Alternatives",
         "release": "August 9, 2024",
@@ -1472,6 +1595,7 @@ const data2024 = [
     // Booster Secret Crysis [BT17] - Special Finish Cards --- bt17_special_alts
     {
         "id": null,
+        "block": 3,
         "slug": "bt17_special_alts",
         "name": "Booster Secret Crysis [BT17] - Special Finish Cards",
         "release": "August 9, 2024",
@@ -1493,6 +1617,7 @@ const data2024 = [
     // Booster Secret Crysis [BT17] - Box Topper --- bt17_boxtopper
     {
         "id": null,
+        "block": 3,
         "slug": "bt17_boxtopper",
         "name": "Booster Secret Crysis [BT17] - Box Topper",
         "release": "August 9, 2024",
@@ -1510,6 +1635,7 @@ const data2024 = [
     // Booster Secret Crysis [BT17] - Update Pack 2024 --- bt17_udate_pack
     {
         "id": null,
+        "block": 3,
         "slug": "bt17_udate_pack",
         "name": "Booster Secret Crysis [BT17] - Update Pack 2024",
         "release": "August 9, 2024",
@@ -1528,6 +1654,7 @@ const data2024 = [
     // Booster Secret Crysis [BT17] - Movie Memorial Pack --- bt17_movie_memorial
     {
         "id": null,
+        "block": 3,
         "slug": "bt17_movie_memorial",
         "name": "Booster Secret Crysis [BT17] - Movie Memorial Pack",
         "release": "August 9, 2024",
@@ -1546,6 +1673,7 @@ const data2024 = [
     // Starter Deck Guardian Vortex [ST18] --- st18
     {
         "id": "ST18",
+        "block": 4,
         "slug": "st18",
         "name": "Starter Deck Guardian Vortex [ST-18]",
         "release": "September 13, 2024",
@@ -1569,6 +1697,8 @@ const data2024 = [
         "id": null,
         "slug": "st18_reprints",
         "name": "Starter Deck Guardian Vortex [ST-18] - Reprints",
+        "reprint": true,
+        "block": 4,
         "release": "September 13, 2024",
         "url": "bandaitcgplusURL/ST18/e_setID-cardIDparallel_D.png",
         "add_zero": 2,
@@ -1589,6 +1719,7 @@ const data2024 = [
     // Starter Deck Fable Waltz [ST19] --- st19
     {
         "id": "ST19",
+        "block": 4,
         "slug": "st19",
         "name": "Starter Deck Fable Waltz [ST-19]",
         "release": "September 13, 2024",
@@ -1611,6 +1742,8 @@ const data2024 = [
         "id": null,
         "slug": "st19_reprints",
         "name": "Starter Deck Fable Waltz [ST-19] - Reprints",
+        "reprint": true,
+        "block": 4,
         "release": "September 13, 2024",
         "url": "bandaitcgplusURL/ST19/e_setID-cardIDparallel_D.png",
         "add_zero": 2,
@@ -1632,6 +1765,7 @@ const data2024 = [
     // Booster Digimon Liberator [EX7] --- ex7
     {
         "id": "EX7",
+        "block": 4,
         "slug": "ex7",
         "name": "Booster Digimon Liberator [EX7]",
         "release": "September 13, 2024",
@@ -1671,6 +1805,7 @@ const data2024 = [
     // Booster Digimon Liberator [EX7] - Alternatives --- ex7_alts
     {
         "id": null,
+        "block": 4,
         "slug": "ex7_alts",
         "name": "Booster Digimon Liberator [EX7] - Alternatives",
         "release": "September 13, 2024",
@@ -1702,6 +1837,7 @@ const data2024 = [
     // Booster Digimon Liberator [EX7] - Limited Cards --- ex7_limited
     {
         "id": null,
+        "block": 4,
         "slug": "ex7_limited",
         "name": "Booster Digimon Liberator [EX7] - Limited Cards",
         "release": "September 13, 2024",
@@ -1755,6 +1891,7 @@ const data2024 = [
     // Booster Digimon Liberator [EX7] - Special Cards --- ex7_special
     {
         "id": null,
+        "block": 4,
         "slug": "ex7_special",
         "name": "Booster Digimon Liberator [EX7] - Special Cards",
         "release": "September 13, 2024",
@@ -1774,6 +1911,7 @@ const data2024 = [
     // Booster Digimon Liberator [EX7] - Legend Pack 2024 --- ex7_legend_pack
     {
         "id": null,
+        "block": 4,
         "slug": "ex7_legend_pack",
         "name": "Booster Digimon Liberator [EX7] - Legend Pack 2024",
         "release": "September 13, 2024",
@@ -1792,6 +1930,12 @@ const data2024 = [
     // Evolution Cup August 2024 Participant Pack --- evolution_cup_participant_august2024
     {
         "id": null,
+        "block": {
+            "1": ["BT9"],
+            "2": ["EX3","RB1"],
+            "3": ["BT14"],
+            "4": ["ST18","P"]
+        },
         "slug": "evolution_cup_participant_august2024",
         "name": "Evolution Cup August 2024 Participant Pack",
         "release": "August 9 – September 10, 2024",
@@ -1810,6 +1954,12 @@ const data2024 = [
     // Evolution Cup August 2024 Top 4 Pack --- evolution_cup_top4_august2024
     {
         "id": null,
+        "block": {
+            "1": ["BT9"],
+            "2": ["EX3","RB1"],
+            "3": ["BT14"],
+            "4": ["ST18","P"]
+        },
         "slug": "evolution_cup_top4_august2024",
         "name": "Evolution Cup August 2024 Top 4 Pack",
         "release": "August 9 – September 10, 2024",
@@ -1828,6 +1978,7 @@ const data2024 = [
     // Evolution Cup August 2024 Champion Card --- evolution_cup_champion_august2024
     {
         "id": null,
+        "block": 4,
         "slug": "evolution_cup_champion_august2024",
         "name": "Evolution Cup August 2024 Champion Card",
         "release": "August 9 – September 10, 2024",
@@ -1842,6 +1993,7 @@ const data2024 = [
     // BANDAI CARD GAMES Fest 24-25 --- bcgfest_24_25
     {
         "id": null,
+        "block": 4,
         "slug": "bcgfest_24_25",
         "name": "BANDAI CARD GAMES Fest 24-25",
         "release": "September 14, 2024 - 2025",
@@ -1854,6 +2006,7 @@ const data2024 = [
     // Premium Card Collection Memory Boost! Set --- premium_memory_boost
     {
         "id": null,
+        "block": 2,
         "slug": "premium_memory_boost",
         "name": "Premium Card Collection Memory Boost! Set",
         "release": "September 14, 2024 - 2025",
@@ -1875,6 +2028,10 @@ const data2024 = [
     // Halloween Event 2024 --- halloween_2024
     {
         "id": null,
+        "block": {
+            "1": ["EX2"],
+            "3": ["BT17","ST17"]
+        },
         "slug": "halloween_2024",
         "name": "Halloween Event 2024",
         "release": "September 13 - October 31, 2024",
@@ -1892,6 +2049,10 @@ const data2024 = [
     // 2024 Regionals Participation Card Set Wave 3 --- regional2024_3_0
     {
         "id": null,
+        "block": {
+            "2": ["BT10","P"],
+            "4": ["BT16","EX6","ST17"]
+        },
         "slug": "regional2024_3_0",
         "name": "2024 Regionals Participant Card Set Wave 3",
         "release": "September-November, 2024",
@@ -1910,6 +2071,10 @@ const data2024 = [
     // 2024 Regionals Finalist Card Set Wave 3 --- regional2024_3_1
     {
         "id": null,
+        "block": {
+            "2": ["BT10","P"],
+            "4": ["BT16","EX6","ST17"]
+        },
         "slug": "regional2024_3_1",
         "name": "2024 Regionals Finalist Card Set Wave 3",
         "release": "September-November, 2024",
@@ -1928,6 +2093,10 @@ const data2024 = [
     // 2024 Regionals Champion Card Set Wave 3 --- regional2024_3_2
     {
         "id": null,
+        "block": {
+            "2": ["BT10","P"],
+            "4": ["BT16","EX6","ST17"]
+        },
         "slug": "regional2024_3_2",
         "name": "2024 Regionals Champion Card Set Wave 3",
         "release": "September-November, 2024",
@@ -1947,6 +2116,12 @@ const data2024 = [
     // Event Pack 7 --- eventpack7
     {
         "id": null,
+        "block": {
+            "0": ["BT4"],
+            "1": ["BT8","BT9"],
+            "2": ["BT12","EX4","ST12"],
+            "3": ["BT16","EX5"]
+        },
         "slug": "eventpack7",
         "name": "Event Pack 7",
         "release": "September-November, 2024",
@@ -1974,6 +2149,7 @@ const data2024 = [
     // Judge Pack 6 --- judgepack6
     {
         "id": null,
+        "block": 3,
         "slug": "judgepack6",
         "name": "Judge Pack 6",
         "release": "September-November, 2024",
@@ -1997,6 +2173,11 @@ const data2024 = [
     // Premium Heroines Set [PB18] --- pb18
     {
         "id": null,
+        "block": {
+            "1": ["BT7","BT8","EX2"],
+            "2": ["BT10","BT11","BT13","RB1"],
+            "3": ["BT14","BT15","BT17","EX6"],
+        },
         "slug": "pb18",
         "name": "Premium Heroines Set [PB18]",
         "release": "October, 2024",
@@ -2023,6 +2204,7 @@ const data2024 = [
     // Store Tournament 2024 Oct.-Dec. - Participation Pack --- otp15
     {
         "id": null,
+        "block": 4,
         "slug": "otp15",
         "name": "Store Tournament 2024 Oct.-Dec. - Participation Pack",
         "release": "October 1 - December 31, 2024",
@@ -2043,6 +2225,7 @@ const data2024 = [
     // Store Tournament 2024 Oct.-Dec. - Winner Pack --- wp15
     {
         "id": null,
+        "block": 4,
         "slug": "wp15",
         "name": "Store Tournament 2024 Oct.-Dec. - Winner Pack",
         "release": "October 1 - December 31, 2024",
@@ -2064,6 +2247,10 @@ const data2024 = [
     // Ultimate Cup 2024 Wave 2 --- ultimatecup_2024_2
     {
         "id": null,
+        "block": {
+            "1": ["BT7"],
+            "2": ["BT12","BT13"]
+        },
         "slug": "ultimatecup_2024_2",
         "name": "Ultimate Cup 2024 Wave 2",
         "release": "October 2024 - February 2025",
@@ -2084,6 +2271,7 @@ const data2024 = [
     // Booster Elemental Successor [BT18]
     {
         "id": "BT18",
+        "block": 4,
         "name": "Booster Elemental Successor [BT18]",
         "release": null,
         "total": 102,
@@ -2125,6 +2313,7 @@ const data2024 = [
     // Booster Xros Evolution [BT19]
     {
         "id": "BT19",
+        "block": 4,
         "name": "Booster Xros Evolution [BT19]",
         "release": null,
         "total": 102,
@@ -2165,6 +2354,7 @@ const data2024 = [
     // Special Booster Ver.2.0 [BT18-19] Celebration Event --- sbt20_prerelease
     {
         "id": null,
+        "block": 1,
         "slug": "sbt20_prerelease",
         "name": "Special Booster Ver.2.0 [BT18-19] Celebration Event",
         "release": "October 25 – November 8, 2024",
@@ -2179,6 +2369,7 @@ const data2024 = [
     // Special Booster Ver.2.0 [BT18-19] --- sbt20
     {
         "id": null,
+        "block": 4,
         "slug": "sbt20",
         "name": "Special Booster Ver.2.0 [BT18-19]",
         "release": "November 2024",
@@ -2347,6 +2538,7 @@ const data2024 = [
     // Special Booster Ver.2.0 [BT18-19] - Alternatives --- sbt20_alts
     {
         "id": null,
+        "block": 4,
         "slug": "sbt20_alts",
         "name": "Special Booster Ver.2.0 [BT18-19] - Alternatives",
         "release": "November 2024",
@@ -2389,6 +2581,7 @@ const data2024 = [
     // Special Booster Ver.2.0 [BT18-19] - Box Topper --- sbt20_boxtopper
     {
         "id": null,
+        "block": 4,
         "slug": "sbt20_boxtopper",
         "name": "Special Booster Ver.2.0 [BT18-19] - Box Topper",
         "release": "November 2024",
@@ -2409,6 +2602,10 @@ const data2024 = [
     // Special Booster Ver.2.0 [BT18-19] - Special Cards --- sbt20_special
     {
         "id": null,
+        "block": {
+            "1": ["EX2"],
+            "4": ["BT18","BT19"]
+        },
         "slug": "sbt20_special",
         "name": "Special Booster Ver.2.0 [BT18-19] - Special Cards",
         "release": "November 2024",
@@ -2438,6 +2635,7 @@ const data2024 = [
     // Special Booster Ver.2.0 [BT18-19] - Signed Cards --- sbt20_signed
     {
         "id": null,
+        "block": 3,
         "slug": "sbt20_signed",
         "name": "Special Booster Ver.2.0 [BT18-19] - Signed Cards",
         "release": "November 2024",
@@ -2451,6 +2649,7 @@ const data2024 = [
     // Digimon Liberator D-Storage Set --- deckbox_2
     {
         "id": null,
+        "block": 4,
         "slug": "deckbox_2",
         "name": "Digimon Liberator D-Storage Set",
         "release": "November 2024",
@@ -2470,6 +2669,11 @@ const data2024 = [
     // Winter Holiday Event 2024 --- whe_2024
     {
         "id": null,
+        "block": {
+            "1": ["BT7"],
+            "2": ["BT10","BT11"],
+            "3": ["BT16"]
+        },
         "slug": "whe_2024",
         "name": "Winter Holiday Event 2024",
         "release": "December 6, 2024 - January 31, 2025",
@@ -2487,6 +2691,11 @@ const data2024 = [
     // 2024 Championship Finals Tamers Pack --- tamerspack_2024
     {
         "id": null,
+        "block": {
+            "1": ["EX1","EX2"],
+            "2": ["RB1"],
+            "3": ["BT14","BT16","BT17"]
+        },
         "slug": "tamerspack_2024",
         "name": "2024 Championship Finals Tamers Pack",
         "release": "December 7 - 8, 2024",
@@ -2506,6 +2715,11 @@ const data2024 = [
     // 2024 Championship Finals Gold Stamp Card Set --- goldstamp_2024
     {
         "id": null,
+        "block": {
+            "1": ["BT8"],
+            "2": ["BT12","BT13"],
+            "3": ["BT14","BT17"]
+        },
         "slug": "goldstamp_2024",
         "name": "2024 Championship Finals Gold Stamp Card Set",
         "release": "December 7 - 8, 2024",
@@ -2529,6 +2743,7 @@ const data2024 = [
     // 2024 Championship Finals Trophy Cards - Top 16 --- cftc_2024_top16
     {
         "id": null,
+        "block": 2,
         "slug": "cftc_2024_top16",
         "name": "2024 Championship Finals Trophy Cards - Top 16",
         "release": "December 7 - 8, 2024",
@@ -2541,6 +2756,7 @@ const data2024 = [
     // 2024 Championship Finals Trophy Cards - 3rd Place --- cftc_2024_top3
     {
         "id": null,
+        "block": 2,
         "slug": "cftc_2024_top3",
         "name": "2024 Championship Finals Trophy Cards - 3rd Place",
         "release": "December 7 - 8, 2024",
@@ -2553,6 +2769,7 @@ const data2024 = [
     // 2024 Championship Finals Trophy Cards - 2nd Place --- cftc_2024_top2
     {
         "id": null,
+        "block": 1,
         "slug": "cftc_2024_top2",
         "name": "2024 Championship Finals Trophy Cards - 2nd Place",
         "release": "December 7 - 8, 2024",
@@ -2565,6 +2782,7 @@ const data2024 = [
     // 2024 Championship Finals Trophy Cards - 1st Place --- cftc_2024_top1
     {
         "id": null,
+        "block": 2,
         "slug": "cftc_2024_top1",
         "name": "2024 Championship Finals Trophy Cards - 1st Place",
         "release": "December 7 - 8, 2024",
@@ -2579,6 +2797,12 @@ const data2024 = [
     // Special Limited Set --- lm02
     {
         "id": null,
+        "block": {
+            "1": ["BT9"],
+            "2": ["BT12","ST12","EX4"],
+            "3": ["BT16","LM-020","LM-021","LM-022","LM-023","LM-024","LM-025","LM-026","LM-027","LM-028","LM-029","LM-030","LM-031","LM-032"],
+            "4": ["EX7","P","LM"]
+        },
         "slug": "lm02",
         "name": "Special Limited Set",
         "release": "December 2024",

--- a/js/data/data_2025.js
+++ b/js/data/data_2025.js
@@ -3,6 +3,7 @@ const data2025 = [
     // Official Store Tournament 2025 Vol.1 - Participation Pack --- otp16
     {
         "id": null,
+        "block": 4,
         "slug": "otp16",
         "name": "Official Store Tournament 2025 Vol.1 - Participation Pack",
         "release": "January 1 - March 31, 2025",
@@ -21,6 +22,7 @@ const data2025 = [
     // Official Store Tournament 2025 Vol.1 - Winner Pack --- wp16
     {
         "id": null,
+        "block": 4,
         "slug": "wp16",
         "name": "Official Store Tournament 2025 Vol.1 - Winner Pack",
         "release": "January 1 - March 31, 2025",
@@ -39,6 +41,7 @@ const data2025 = [
     // Booster Chain of Liberation [EX8] --- ex8
     {
         "id": "EX8",
+        "block": 4,
         "slug": "ex8",
         "name": "Booster Chain of Liberation [EX8]",
         "release": "January 10, 2025",
@@ -78,6 +81,7 @@ const data2025 = [
     // Booster Chain of Liberation [EX8] - Alternatives --- ex8_alts
     {
         "id": null,
+        "block": 4,
         "slug": "ex8_alts",
         "name": "Booster Chain of Liberation [EX8] - Alternatives",
         "release": "January 10, 2025",
@@ -109,6 +113,7 @@ const data2025 = [
     // Booster Chain of Liberation [EX8] - Limited Cards --- ex8_limited
     {
         "id": null,
+        "block": 4,
         "slug": "ex8_limited",
         "name": "Booster Chain of Liberation [EX8] - Limited Cards",
         "release": "January 10, 2025",
@@ -162,6 +167,7 @@ const data2025 = [
     // Booster Chain of Liberation [EX8] - Special Cards --- ex8_special
     {
         "id": null,
+        "block": 4,
         "slug": "ex8_special",
         "name": "Booster Chain of Liberation [EX8] - Special Cards",
         "release": "January 10, 2025",
@@ -183,6 +189,7 @@ const data2025 = [
     // Booster Chain of Liberation [EX8] - Legend Pack 2024 --- ex8_legend_pack
     {
         "id": null,
+        "block": 4,
         "slug": "ex8_legend_pack",
         "name": "Booster Chain of Liberation [EX8] - Legend Pack 2024",
         "release": "January 10, 2025",
@@ -199,6 +206,7 @@ const data2025 = [
     // Booster Chain of Liberation [EX8] - Upgrade Pack --- ex8_upgrade_pack
     {
         "id": null,
+        "block": 4,
         "slug": "ex8_upgrade_pack",
         "name": "Booster Chain of Liberation [EX8] - Upgrade Pack",
         "release": "January 10, 2025",
@@ -217,6 +225,7 @@ const data2025 = [
     // Omnimon Binder Set [PB19] --- pb19
     {
         "id": null,
+        "block": 3,
         "slug": "pb19",
         "name": "Omnimon Binder Set [PB19]",
         "release": "February 2025",
@@ -238,6 +247,7 @@ const data2025 = [
     // Booster Over The X [BT20]
     {
         "id": "BT20",
+        "block": 4,
         "name": "Booster Over The X [BT20]",
         "release": null,
         "total": 102,
@@ -282,6 +292,7 @@ const data2025 = [
     // Special Booster Ver.2.5 [BT19-20] Celebration Event --- sbt25_prerelease
     {
         "id": null,
+        "block": 4,
         "slug": "sbt25_prerelease",
         "name": "Special Booster Ver.2.5 [BT19-20] Celebration Event",
         "release": "February 21 – March 7, 2025",
@@ -295,6 +306,7 @@ const data2025 = [
     // Special Booster Ver.2.5 [BT19-20] --- sbt25
     {
         "id": null,
+        "block": 4,
         "slug": "sbt25",
         "name": "Special Booster Ver.2.5 [BT19-20]",
         "release": "February 2025",
@@ -468,6 +480,7 @@ const data2025 = [
     // Special Booster Ver.2.5 [BT19-20] - Alternatives --- sbt25_alts
     {
         "id": null,
+        "block": 4,
         "slug": "sbt25_alts",
         "name": "Special Booster Ver.2.5 [BT19-20] - Alternatives",
         "release": "February 2025",
@@ -508,6 +521,7 @@ const data2025 = [
     // Special Booster Ver.2.5 [BT19-20] - Box Topper --- sbt25_boxtopper
     {
         "id": null,
+        "block": 4,
         "slug": "sbt25_boxtopper",
         "name": "Special Booster Ver.2.5 [BT19-20] - Box Topper",
         "release": "February 2025",
@@ -531,6 +545,7 @@ const data2025 = [
     // Special Booster Ver.2.5 [BT19-20] - Special Cards --- sbt25_special
     {
         "id": null,
+        "block": 4,
         "slug": "sbt25_special",
         "name": "Special Booster Ver.2.5 [BT19-20] - Special Cards",
         "release": "February 2025",
@@ -561,6 +576,7 @@ const data2025 = [
     // Special Booster Ver.2.5 [BT19-20] - Signed Cards --- sbt25_signed
     {
         "id": null,
+        "block": 4,
         "slug": "sbt25_signed",
         "name": "Special Booster Ver.2.5 [BT19-20] - Signed Cards",
         "release": "February 2025",
@@ -573,6 +589,7 @@ const data2025 = [
     // Special Booster Ver.2.5 [BT19-20] - Serial Cards --- sbt25_serial
     {
         "id": null,
+        "block": 3,
         "slug": "sbt25_serial",
         "name": "Special Booster Ver.2.5 [BT19-20] - Serial Cards",
         "release": "February 2025",
@@ -586,6 +603,7 @@ const data2025 = [
     // Special Booster Ver.2.5 [BT19-20] - Update Pack 2025 --- sbt25_update_pack
     {
         "id": null,
+        "block": 4,
         "slug": "sbt25_update_pack",
         "name": "Special Booster Ver.2.5 [BT19-20] - Update Pack 2025",
         "release": "February 2025",
@@ -606,6 +624,11 @@ const data2025 = [
     // 2025 Regionals Participation Card Set Season 1 --- regional2025_1_0
     {
         "id": null,
+        "block": {
+            "1": ["BT8"],
+            "3": ["BT14"],
+            "4": ["BT18","BT20","EX7"],
+        },
         "slug": "regional2025_1_0",
         "name": "2025 Regionals Participation Card Set Season 1",
         "release": "March - June, 2025",
@@ -624,6 +647,11 @@ const data2025 = [
     // 2025 Regionals Finalist Card Set Season 1 --- regional2025_1_1
     {
         "id": null,
+        "block": {
+            "1": ["BT8"],
+            "3": ["BT14"],
+            "4": ["BT18","BT20","EX7"],
+        },
         "slug": "regional2025_1_1",
         "name": "2025 Regionals Finalist Card Set Season 1",
         "release": "March - June, 2025",
@@ -642,6 +670,11 @@ const data2025 = [
     // 2025 Regionals Champion Card Set Season 1 --- regional2025_1_2
     {
         "id": null,
+        "block": {
+            "1": ["BT8"],
+            "3": ["BT14"],
+            "4": ["BT18","BT20","EX7"],
+        },
         "slug": "regional2025_1_2",
         "name": "2025 Regionals Champion Card Set Season 1",
         "release": "March - June, 2025",
@@ -660,6 +693,11 @@ const data2025 = [
     // Special Event Pack 2025 --- special_eventpack_2025
     {
         "id": null,
+        "block": {
+            "1": ["BT7","EX1"],
+            "2": ["BT10","BT12","ST14"],
+            "3": ["EX5","P"]
+        },
         "slug": "special_eventpack_2025",
         "name": "Special Event Pack 2025",
         "release": "March - June, 2025",
@@ -678,6 +716,7 @@ const data2025 = [
     // Judge Pack 2025 Season 1 --- judgepack7
     {
         "id": null,
+        "block": 4,
         "slug": "judgepack7",
         "name": "Judge Pack 2025 Season 1",
         "release": "March - June, 2025",
@@ -702,6 +741,7 @@ const data2025 = [
     // 24-25 World Championship - Participation --- wc2024
     {
         "id": null,
+        "block": 2,
         "slug": "wc2024",
         "name": "24-25 World Championship - Participation",
         "release": "March 15-16, 2025",
@@ -715,6 +755,7 @@ const data2025 = [
     // 24-25 World Championship - 3rd Place Prize --- wc2024_3rd
     {
         "id": null,
+        "block": 2,
         "slug": "wc2024_3rd",
         "name": "24-25 World Championship - 3rd Place Prize",
         "release": "March 15-16, 2025",
@@ -727,6 +768,7 @@ const data2025 = [
     // 24-25 World Championship - Runner-Up Prize --- wc2024_2nd
     {
         "id": null,
+        "block": 1,
         "slug": "wc2024_2nd",
         "name": "24-25 World Championship - Runner-Up Prize",
         "release": "March 15-16, 2025",
@@ -739,6 +781,7 @@ const data2025 = [
     // 24-25 World Championship - Champion Prize --- wc2024_1st
     {
         "id": null,
+        "block": 2,
         "slug": "wc2024_1st",
         "name": "24-25 World Championship - Champion Prize",
         "release": "March 15-16, 2025",
@@ -753,6 +796,7 @@ const data2025 = [
     // Starter Deck Protector of Light [ST20] --- st20
     {
         "id": "ST20",
+        "block": 5,
         "slug": "st20",
         "name": "Starter Deck Protector of Light [ST-20]",
         "release": "April 2025",
@@ -780,6 +824,7 @@ const data2025 = [
     // Starter Deck Protector of Light [ST20] - Lucky Deck --- st20_lucky
     {
         "id": null,
+        "block": 5,
         "slug": "st20_lucky",
         "name": "Starter Deck Protector of Light [ST20] - Lucky Deck",
         "release": "April 2025",
@@ -792,6 +837,7 @@ const data2025 = [
     // Starter Deck Protector of Light [ST20] - Scramble --- st20_scramble
     {
         "id": null,
+        "block": 5,
         "slug": "st20_scramble",
         "name": "Starter Deck Protector of Light [ST20] - Scramble",
         "release": "April 2025",
@@ -809,6 +855,7 @@ const data2025 = [
     // Starter Deck Hero of Hope [ST21] --- st21
     {
         "id": "ST21",
+        "block": 5,
         "slug": "st21",
         "name": "Starter Deck Hero of Hope [ST-21]",
         "release": "April 2025",
@@ -836,6 +883,7 @@ const data2025 = [
     // Starter Deck Hero of Hope [ST21] - Lucky Deck --- st21_lucky
     {
         "id": null,
+        "block": 5,
         "slug": "st21_lucky",
         "name": "Starter Deck Hero of Hope [ST21] - Lucky Deck",
         "release": "April 2025",
@@ -848,6 +896,7 @@ const data2025 = [
     // Starter Deck Hero of Hope [ST21] - Scramble --- st21_scramble
     {
         "id": null,
+        "block": 5,
         "slug": "st21_scramble",
         "name": "Starter Deck Hero of Hope [ST21] - Scramble",
         "release": "April 2025",
@@ -866,6 +915,7 @@ const data2025 = [
     // WORLD CONVERGENCE [BT-21] Release Event --- bt21_prerelease
     {
         "id": null,
+        "block": 3,
         "slug": "bt21_prerelease",
         "name": "WORLD CONVERGENCE [BT-21] Release Event",
         "release": "April 18 – May 9, 2025",
@@ -879,6 +929,7 @@ const data2025 = [
     // Booster World Convergence [BT21] --- bt21
     {
         "id": "BT21",
+        "block": 5,
         "slug": "bt21",
         "name": "Booster World Convergence [BT21]",
         "release": "April 2025",
@@ -927,6 +978,7 @@ const data2025 = [
     // Booster World Convergence [BT21] - Alternatives --- bt21_alts
     {
         "id": null,
+        "block": 5,
         "slug": "bt21_alts",
         "name": "Booster World Convergence [BT21] - Alternatives",
         "release": "April 2025",
@@ -958,6 +1010,7 @@ const data2025 = [
     // Booster World Convergence [BT21] - Special Cards --- bt21_special
     {
         "id": null,
+        "block": 5,
         "slug": "bt21_special",
         "name": "Booster World Convergence [BT21] - Special Cards",
         "release": "April 2025",
@@ -977,6 +1030,12 @@ const data2025 = [
     // Booster World Convergence [BT21] - Signed Cards --- bt21_signed
     {
         "id": null,
+        "block": {
+            "1": ["BT6","BT9","EX1"],
+            "2": ["BT13"],
+            "3": ["EX5"],
+            "4": ["BT18","EX7"]
+        },
         "slug": "bt21_signed",
         "name": "Booster World Convergence [BT21] - Signed Cards",
         "release": "April 2025",
@@ -996,6 +1055,7 @@ const data2025 = [
     // Booster World Convergence [BT21] - Illustration Celebration Pack --- bt21_ilu_cel_pack
     {
         "id": null,
+        "block": 5,
         "slug": "bt21_ilu_cel_pack",
         "name": "Booster World Convergence [BT21] - Illustration Celebration Pack",
         "release": "April 2025",
@@ -1014,6 +1074,12 @@ const data2025 = [
     // Booster World Convergence [BT21] - Limited Card Pack --- bt21_limited
     {
         "id": null,
+        "block": {
+            "1": ["EX1"],
+            "2": ["BT13"],
+            "3": ["BT14","BT15","EX5"],
+            "4": ["LM"]
+        },
         "slug": "bt21_limited",
         "name": "Booster World Convergence [BT21] - Limited Card Pack",
         "release": "April 2025",
@@ -1037,6 +1103,7 @@ const data2025 = [
     // Regulation Battle Vol.1 --- rb_1
     {
         "id": null,
+        "block": 3,
         "slug": "rb_1",
         "name": "Regulation Battle Vol.1",
         "release": "April 1 – May 31, 2025",
@@ -1051,6 +1118,7 @@ const data2025 = [
     // Official Store Tournament 2025 Vol.2 - Participation Pack --- otp17
     {
         "id": null,
+        "block": 5,
         "slug": "otp17",
         "name": "Official Store Tournament 2025 Vol.2 - Participation Pack",
         "release": "April 1 - June 30, 2025",
@@ -1069,6 +1137,7 @@ const data2025 = [
     // Official Store Tournament 2025 Vol.2 - Winner Pack --- wp17
     {
         "id": null,
+        "block": 5,
         "slug": "wp17",
         "name": "Official Store Tournament 2025 Vol.2 - Winner Pack",
         "release": "April 1 - June 30, 2025",
@@ -1087,6 +1156,10 @@ const data2025 = [
     // Ultimate Cup 25-26 Season 1 --- ultimatecup_2025_1
     {
         "id": null,
+        "block": {
+            "2": ["BT12"],
+            "4": ["BT19"]
+        },
         "slug": "ultimatecup_2025_1",
         "name": "Ultimate Cup 25-26 Season 1",
         // "release": "October 2024 - February 2025",
@@ -1103,6 +1176,11 @@ const data2025 = [
     // DIGIMON ANIMATION SERIES 25th Anniversary Set [PB20] --- pb20
     {
         "id": null,
+        "block": {
+            "1": ["BT7","EX2"],
+            "2": ["BT1","BT3","BT10","BT12","BT13","RB1"],
+            "4": ["P"]
+        },
         "slug": "pb20",
         "name": "DIGIMON ANIMATION SERIES 25th Anniversary Set [PB20]",
         "release": "May 2025",
@@ -1124,21 +1202,25 @@ const data2025 = [
     // TAMER'S SELECTION BOX ver. CHAMPIONSHIP 2024 --- tamer_champion_24
     {
         "id": null,
+        "block": {
+            "3": ["BT17"],
+            "4": ["BT18"]
+        },
         "slug": "tamer_champion_24",
         "name": "TAMER'S SELECTION BOX ver. CHAMPIONSHIP 2024",
         "release": "May 2025",
-        "url": "noCardURL",
+        "url": "digimoncardURL/setID-cardID_parallel.png",
         "cards": {
-            "BT17-017": "",
-            "BT17-028": "",
-            "BT18-017": "",
-            "BT18-028": "",
-            "BT18-029": "",
-            "BT18-054": "",
-            "BT18-055": "",
-            "BT18-072": "",
-            "BT18-074": "",
-            "BT18-084": "",
+            "BT17-017": "P2",
+            "BT17-028": "P2",
+            "BT18-017": "P1",
+            "BT18-028": "P1",
+            "BT18-029": "P1",
+            "BT18-054": "P1",
+            "BT18-055": "P1",
+            "BT18-072": "P1",
+            "BT18-074": "P1",
+            "BT18-084": "P1",
         },
         "info_url": "https://world.digimoncard.com/products/goods/tamer-selection-box-cs2024.php"
     },
@@ -1147,6 +1229,7 @@ const data2025 = [
     // Evolution Cup 2025 Vol. 1 Participation --- evolution_cup_2025_1_participant
     {
         "id": null,
+        "block": 1,
         "slug": "evolution_cup_2025_1_participant",
         "name": "Evolution Cup 2025 Vol. 1 Participation",
         "release": "June 1 – July 31, 2025",
@@ -1159,6 +1242,7 @@ const data2025 = [
     // Evolution Cup 2025 Vol. 1 Top 4 --- evolution_cup_2025_1_top4
     {
         "id": null,
+        "block": 1,
         "slug": "evolution_cup_2025_1_top4",
         "name": "Evolution Cup 2025 Vol. 1 Top 4",
         "release": "June 1 – July 31, 2025",
@@ -1171,6 +1255,7 @@ const data2025 = [
     // Evolution Cup 2025 Vol. 1 Winner --- evolution_cup_2025_1_winner
     {
         "id": null,
+        "block": 2,
         "slug": "evolution_cup_2025_1_winner",
         "name": "Evolution Cup 2025 Vol. 1 Winner",
         "release": "June 1 – July 31, 2025",
@@ -1185,6 +1270,7 @@ const data2025 = [
     // Booster Versus Monsters [EX9] --- ex9
     {
         "id": "EX9",
+        "block": 5,
         "slug": "ex9",
         "name": "Booster Versus Monsters [EX9]",
         "release": "June 26, 2025",
@@ -1226,6 +1312,7 @@ const data2025 = [
     // Booster Versus Monsters [EX9] - Alternatives --- ex9_alts
     {
         "id": null,
+        "block": 5,
         "slug": "ex9_alts",
         "name": "Booster Versus Monsters [EX9] - Alternatives",
         "release": "June 26, 2025",
@@ -1257,6 +1344,7 @@ const data2025 = [
     // Booster Versus Monsters [EX9] - Limited Cards --- ex9_limited
     {
         "id": null,
+        "block": 5,
         "slug": "ex9_limited",
         "name": "Booster Versus Monsters [EX9] - Limited Cards",
         "release": "June 26, 2025",
@@ -1310,6 +1398,7 @@ const data2025 = [
     // Booster Versus Monsters [EX9] - Special Cards --- ex9_special
     {
         "id": null,
+        "block": 5,
         "slug": "ex9_special",
         "name": "Booster Versus Monsters [EX9] - Special Cards",
         "release": "June 26, 2025",
@@ -1330,6 +1419,7 @@ const data2025 = [
     // Booster Versus Monsters [EX9] - Legend Pack --- ex9_legend_pack
     {
         "id": null,
+        "block": 5,
         "slug": "ex9_legend_pack",
         "name": "Booster Versus Monsters [EX9] - Legend Pack",
         "release": "June 26, 2025",
@@ -1346,6 +1436,7 @@ const data2025 = [
     // Digital Monster Day Commemoration Event --- ex9_prerelease
     {
         "id": null,
+        "block": 5,
         "slug": "ex9_prerelease",
         "name": "Digital Monster Day Commemoration Event",
         "release": "June 26 - July 3, 2025",
@@ -1360,6 +1451,10 @@ const data2025 = [
     // Regulation Battle Vol.2 --- rb_2
     {
         "id": null,
+        "block": {
+            "3": ["EX6"],
+            "4": ["ST19"]
+        },
         "slug": "rb_2",
         "name": "Regulation Battle Vol.2",
         "release": "July 1 – August 31, 2025",
@@ -1375,6 +1470,7 @@ const data2025 = [
     // Official Store Tournament 2025 Vol.3 - Participation Pack --- otp18
     {
         "id": null,
+        "block": 5,
         "slug": "otp18",
         "name": "Official Store Tournament 2025 Vol.3 - Participation Pack",
         "release": "July 1 - September 30, 2025",
@@ -1393,6 +1489,7 @@ const data2025 = [
     // Official Store Tournament 2025 Vol.3 - Winner Pack --- wp18
     {
         "id": null,
+        "block": 5,
         "slug": "wp18",
         "name": "Official Store Tournament 2025 Vol.3 - Winner Pack",
         "release": "July 1 - September 30, 2025",
@@ -1412,6 +1509,7 @@ const data2025 = [
     // CYBER EDEN [BT22] Release Event --- bt22_prerelease
     {
         "id": null,
+        "block": 3,
         "slug": "bt22_prerelease",
         "name": "CYBER EDEN [BT-22] Release Event",
         "release": "July 18 - 24, 2025",
@@ -1426,6 +1524,7 @@ const data2025 = [
     // Booster Cyber Eden [BT22] --- bt22
     {
         "id": "BT22",
+        "block": 5,
         "slug": "bt22",
         "name": "Booster Cyber Eden [BT22]",
         "release": "July 25, 2025",
@@ -1482,6 +1581,7 @@ const data2025 = [
     // Booster Cyber Eden [BT22] - Alternatives --- bt22_alts
     {
         "id": null,
+        "block": 5,
         "slug": "bt22_alts",
         "name": "Booster Cyber Eden [BT22] - Alternatives",
         "release": "July 25, 2025",
@@ -1513,6 +1613,7 @@ const data2025 = [
     // Booster Cyber Eden [BT22] - Special Cards --- bt22_special
     {
         "id": null,
+        "block": 5,
         "slug": "bt22_special",
         "name": "Booster Cyber Eden [BT22] - Special Cards",
         "release": "July 25, 2025",
@@ -1533,6 +1634,7 @@ const data2025 = [
     // Booster Cyber Eden [BT22] - Box Promotion Pack --- bt22_boxtopper
     {
         "id": null,
+        "block": 5,
         "slug": "bt22_boxtopper",
         "name": "Booster Cyber Eden [BT22] - Box Promotion Pack",
         "release": "July 25, 2025",
@@ -1552,6 +1654,11 @@ const data2025 = [
     // 2025 Regionals Participation Card Set Season 2 --- regional2025_2_0
     {
         "id": null,
+        "block": {
+            "1": ["ST10"],
+            "3": ["BT14","BT17"],
+            "4": ["BT20","EX8"]
+        },
         "slug": "regional2025_2_0",
         "name": "2025 Regionals Participation Card Set Season 2",
         "release": "August - September, 2025",
@@ -1576,6 +1683,11 @@ const data2025 = [
     // 2025 Regionals Finalist Card Set Season 2 --- regional2025_2_1
     {
         "id": null,
+        "block": {
+            "1": ["ST10"],
+            "3": ["BT14","BT17"],
+            "4": ["BT20","EX8"]
+        },
         "slug": "regional2025_2_1",
         "name": "2025 Regionals Finalist Card Set Season 2",
         "release": "August - September, 2025",
@@ -1600,6 +1712,11 @@ const data2025 = [
     // 2025 Regionals Champion Card Set Season 2 --- regional2025_2_2
     {
         "id": null,
+        "block": {
+            "1": ["ST10"],
+            "3": ["BT14","BT17"],
+            "4": ["BT20","EX8"]
+        },
         "slug": "regional2025_2_2",
         "name": "2025 Regionals Champion Card Set Season 2",
         "release": "August - September, 2025",
@@ -1624,6 +1741,10 @@ const data2025 = [
     // Event Pack 8 --- eventpack8
     {
         "id": null,
+        "block": {
+            "4": ["P-164","P-165","P-166","P-167","P-168","P-169",],
+            "5": ["P"]
+        },
         "slug": "eventpack8",
         "name": "Event Pack 8",
         "release": "August - September, 2025",
@@ -1647,6 +1768,7 @@ const data2025 = [
     // Judge Pack 2025 Wave 2 --- judgepack8
     {
         "id": null,
+        "block": 5,
         "slug": "judgepack8",
         "name": "Judge Pack 2025 Wave 2",
         "release": "August - September, 2025",
@@ -1670,6 +1792,7 @@ const data2025 = [
     // Ultimate Cup 25-26 Season 2 --- ultimatecup_2025_2
     {
         "id": null,
+        "block": 5,
         "slug": "ultimatecup_2025_2",
         "name": "Ultimate Cup 25-26 Season 2",
         "release": "August - September, 2025",
@@ -1686,6 +1809,14 @@ const data2025 = [
     // Time Stranger Tutorial Deck --- timestranger_tutorial_deck
     {
         "id": null,
+        "block": {
+            "0": ["BT1","BT3-037"],
+            "1": ["EX1","BT8"],
+            "2": ["BT3","ST10"],
+            "3": ["BT14","BT15"],
+            "4": ["BT18","EX7","P-037"],
+            "5": ["P"] // "P-191","P-194","P-195"
+        },
         "slug": "timestranger_tutorial_deck",
         "name": "Time Stranger Tutorial Deck",
         "release": "August 20-24, 2025",
@@ -1734,6 +1865,7 @@ const data2025 = [
     // Evolution Cup 2025 Vol. 2 Top 4 --- evolution_cup_2025_2_top4
     {
         "id": null,
+        "block": 3,
         "slug": "evolution_cup_2025_2_top4",
         "name": "Evolution Cup 2025 Vol. 2 Top 4",
         "release": "September 1 – October 31, 2025",
@@ -1746,6 +1878,7 @@ const data2025 = [
     // Evolution Cup 2025 Vol. 2 Winner --- evolution_cup_2025_2_winner
     {
         "id": null,
+        "block": 0,
         "slug": "evolution_cup_2025_2_winner",
         "name": "Evolution Cup 2025 Vol. 2 Winner",
         "release": "September 1 – October 31, 2025",
@@ -1760,6 +1893,7 @@ const data2025 = [
     // Extra Booster Sinister Order [EX10] --- ex10
     {
         "id": "EX10",
+        "block": 5,
         "slug": "ex10",
         "name": "Extra Booster Sinister Order [EX10]",
         "release": "September 19, 2025",
@@ -1807,6 +1941,7 @@ const data2025 = [
     // Extra Booster Sinister Order [EX10] - Alternatives --- ex10_alts
     {
         "id": null,
+        "block": 5,
         "slug": "ex10_alts",
         "name": "Extra Booster Sinister Order [EX10] - Alternatives",
         "release": "September 19, 2025",
@@ -1838,6 +1973,7 @@ const data2025 = [
     // Extra Booster Sinister Order [EX10] - Limited Cards --- ex10_limited
     {
         "id": null,
+        "block": 5,
         "slug": "ex10_limited",
         "name": "Extra Booster Sinister Order [EX10] - Limited Cards",
         "release": "September 19, 2025",
@@ -1891,6 +2027,7 @@ const data2025 = [
     // Extra Booster Sinister Order [EX10] - Special Cards --- ex10_special
     {
         "id": null,
+        "block": 5,
         "slug": "ex10_special",
         "name": "Extra Booster Sinister Order [EX10] - Special Cards",
         "release": "September 19, 2025",
@@ -1908,6 +2045,10 @@ const data2025 = [
     // Extra Booster Sinister Order [EX10] - Legend Pack --- ex10_legend_pack
     {
         "id": null,
+        "block": {
+            "2": ["ST14"],
+            "3": ["BT8","BT15","LM","P"]
+        },
         "slug": "ex10_legend_pack",
         "name": "Extra Booster Sinister Order [EX10] - Legend Pack",
         "release": "September 19, 2025",
@@ -1926,6 +2067,7 @@ const data2025 = [
     // BANDAI CARD GAMES Fest 25-26 --- bcgfest_25_26
     {
         "id": null,
+        "block": 5,
         "slug": "bcgfest_25_26",
         "name": "BANDAI CARD GAMES Fest 25-26",
         "release": "September 20, 2025 - 2026",
@@ -1938,6 +2080,7 @@ const data2025 = [
     // PREMIUM CARD COLLECTION Digimon Training Set --- premium_training
     {
         "id": null,
+        "block": 4,
         "slug": "premium_training",
         "name": "PREMIUM CARD COLLECTION Digimon Training Set",
         "release": "September 20, 2025 - 2026",
@@ -1959,6 +2102,12 @@ const data2025 = [
     // Championship 25-26 Finals Season 1 Tamers Pack/Set --- championship_2526_finals_1_tamers
     {
         "id": null,
+        "block": {
+            "0": ["BT5"],
+            "1": ["BT8"],
+            "2": ["EX4"],
+            "4": ["BT19"]
+        },
         "slug": "championship_2526_finals_1_tamers",
         "name": "Championship 25-26 Finals Season 1 Tamers Pack/Set",
         "release": "September 20-21, 2025",
@@ -1976,6 +2125,7 @@ const data2025 = [
     // Championship 25-26 Finals Season 1 - Top 32 --- championship_2526_finals_1_top32
     {
         "id": null,
+        "block": 4,
         "slug": "championship_2526_finals_1_top32",
         "name": "Championship 25-26 Finals Season 1 - Top 32",
         "release": "September 20-21, 2025",
@@ -1988,6 +2138,7 @@ const data2025 = [
     // Championship 25-26 Finals Season 1 - Top 16 --- championship_2526_finals_1_top16
     {
         "id": null,
+        "block": 3,
         "slug": "championship_2526_finals_1_top16",
         "name": "Championship 25-26 Finals Season 1 - Top 16",
         "release": "September 20-21, 2025",
@@ -2000,6 +2151,7 @@ const data2025 = [
     // Championship 25-26 Finals Season 1 - 3rd Place --- championship_2526_finals_1_3rd
     {
         "id": null,
+        "block": 3,
         "slug": "championship_2526_finals_1_3rd",
         "name": "Championship 25-26 Finals Season 1 - 3rd Place",
         "release": "September 20-21, 2025",
@@ -2012,6 +2164,7 @@ const data2025 = [
     // Championship 25-26 Finals Season 1 - 2nd Place --- championship_2526_finals_1_2nd
     {
         "id": null,
+        "block": 3,
         "slug": "championship_2526_finals_1_2nd",
         "name": "Championship 25-26 Finals Season 1 - 2nd Place",
         "release": "September 20-21, 2025",
@@ -2024,6 +2177,7 @@ const data2025 = [
     // Championship 25-26 Finals Season 1 - 1st Place --- championship_2526_finals_1_1st
     {
         "id": null,
+        "block": 3,
         "slug": "championship_2526_finals_1_1st",
         "name": "Championship 25-26 Finals Season 1 - 1st Place",
         "release": "September 20-21, 2025",
@@ -2038,6 +2192,7 @@ const data2025 = [
     // Limited Card Pack BILLION BULLET --- lm03
     {
         "id": null,
+        "block": 5,
         "slug": "lm03",
         "name": "Limited Card Pack BILLION BULLET",
         "release": "October 2025",
@@ -2055,6 +2210,10 @@ const data2025 = [
     // Limited Card Pack BILLION BULLET - Alternatives --- lm03_alts
     {
         "id": null,
+        "block": {
+            "3": ["BT16","ST17"],
+            "4": ["BT19"]
+        },
         "slug": "lm03_alts",
         "name": "Limited Card Pack BILLION BULLET - Alternatives",
         "release": "October 2025",
@@ -2070,6 +2229,12 @@ const data2025 = [
     // Limited Card Pack BILLION BULLET - Reprints --- lm03_reprints
     {
         "id": null,
+        "block": {
+            "0": ["BT3","ST6"],
+            "2": ["BT11","BT12","EX4","RB1","P-094"],
+            "3": ["BT16","BT17","ST16","P-137"],
+            "4": ["BT18","P"]
+        },
         "slug": "lm03_reprints",
         "name": "Limited Card Pack BILLION BULLET - Reprints",
         "release": "October 2025",
@@ -2106,6 +2271,10 @@ const data2025 = [
     // Regulation Battle Vol.3 --- rb_3
     {
         "id": null,
+        "block": {
+            "1": ["BT7"],
+            "5": ["BT21"]
+        },
         "slug": "rb_3",
         "name": "Regulation Battle Vol.3",
         "release": "October 1 – November 30, 2025",
@@ -2121,6 +2290,7 @@ const data2025 = [
     // Official Store Tournament 2025 Vol.4 - Participation Pack --- otp19
     {
         "id": null,
+        "block": 5,
         "slug": "otp19",
         "name": "Official Store Tournament 2025 Vol.4 - Participation Pack",
         "release": "October 1 – December 31, 2025",
@@ -2139,6 +2309,7 @@ const data2025 = [
     // Official Store Tournament 2025 Vol.4 - Winner Pack --- wp19
     {
         "id": null,
+        "block": 5,
         "slug": "wp19",
         "name": "Official Store Tournament 2025 Vol.4 - Winner Pack",
         "release": "October 1 – December 31, 2025",
@@ -2156,6 +2327,7 @@ const data2025 = [
     // Time Stranger Promo Pack --- timestranger_pack
     {
         "id": null,
+        "block": 5,
         "slug": "timestranger_pack",
         "name": "Time Stranger Promo Pack",
         "release": "October 1 – December 31, 2025",
@@ -2180,6 +2352,10 @@ const data2025 = [
     // Digimon Story Time Stranger - Collector's Edition --- digimon_time_stranger
     {
         "id": null,
+        "block": {
+            "3": ["EX5"],
+            "5": ["P"]
+        },
         "slug": "digimon_time_stranger",
         "name": "Digimon Story Time Stranger - Collector's Edition",
         "release": "October 3, 2025",
@@ -2197,6 +2373,7 @@ const data2025 = [
     // HACKERS’ SLUMBER [BT-23] Release Event --- bt23_prerelease
     {
         "id": null,
+        "block": 3,
         "slug": "bt23_prerelease",
         "name": "HACKERS’ SLUMBER [BT-23] Release Event",
         "release": "October 17 - 23, 2025",
@@ -2211,6 +2388,7 @@ const data2025 = [
     // Booster Hackers' Slumber [BT-23] --- bt23
     {
         "id": "BT23",
+        "block": 5,
         "slug": "bt23",
         "name": "Booster Hackers' Slumber [BT-23]",
         "release": "October 24, 2025",
@@ -2257,6 +2435,7 @@ const data2025 = [
     // Booster Hackers' Slumber [BT-23] - Alternatives --- bt23_alts
     {
         "id": null,
+        "block": 5,
         "slug": "bt23_alts",
         "name": "Booster Hackers' Slumber [BT-23] - Alternatives",
         "release": "October 24, 2025",
@@ -2288,6 +2467,7 @@ const data2025 = [
     // Booster Hackers' Slumber [BT-23] - Special Cards --- bt23_special
     {
         "id": null,
+        "block": 5,
         "slug": "bt23_special",
         "name": "Booster Hackers' Slumber [BT-23] - Special Cards",
         "release": "October 24, 2025",
@@ -2305,6 +2485,7 @@ const data2025 = [
     // Booster Hackers' Slumber [BT-23] - Box Promotion Pack --- bt23_boxtopper
     {
         "id": null,
+        "block": 5,
         "slug": "bt23_boxtopper",
         "name": "Booster Hackers' Slumber [BT-23] - Box Promotion Pack",
         "release": "October 24, 2025",
@@ -2336,10 +2517,11 @@ const data2025 = [
     // Evolution Cup 2025 Vol. 3 Participation --- evolution_cup_2025_3_participant
     {
         "id": null,
+        "block": 5,
         "slug": "evolution_cup_2025_3_participant",
         "name": "Evolution Cup 2025 Vol. 3 Participation",
         "release": "December 1, 2025 – January 31, 2026",
-        "url": "noCardURL",
+        "url": "bandaitcgplusURL/P/e_setID-cardID_D.png",
         "cards": {
             "BT22-026": "",
         },
@@ -2348,10 +2530,11 @@ const data2025 = [
     // Evolution Cup 2025 Vol. 3 Top 4 --- evolution_cup_2025_3_top4
     {
         "id": null,
+        "block": 5,
         "slug": "evolution_cup_2025_3_top4",
         "name": "Evolution Cup 2025 Vol. 3 Top 4",
         "release": "December 1, 2025 – January 31, 2026",
-        "url": "noCardURL",
+        "url": "bandaitcgplusURL/P/e_setID-cardID_D.png",
         "cards": {
             "BT22-013": "",
         },
@@ -2360,10 +2543,11 @@ const data2025 = [
     // Evolution Cup 2025 Vol. 3 Winner --- evolution_cup_2025_3_winner
     {
         "id": null,
+        "block": 2,
         "slug": "evolution_cup_2025_3_winner",
         "name": "Evolution Cup 2025 Vol. 3 Winner",
         "release": "December 1, 2025 – January 31, 2026",
-        "url": "noCardURL",
+        "url": "bandaitcgplusURL/P/e_setID-cardID_D.png",
         "cards": {
             "BT5-092": "",
         },
@@ -2374,6 +2558,7 @@ const data2025 = [
     // Advanced Deck Amethyst Mandala [ST-22] --- st22
     {
         "id": "ST22",
+        "block": 5,
         "slug": "st22",
         "name": "Advanced Deck Amethyst Mandala [ST-22]",
         "release": "December 5, 2025",
@@ -2401,6 +2586,7 @@ const data2025 = [
     // Advanced Deck Amethyst Mandala [ST-22] - Lucky Deck --- st22_lucky
     {
         "id": null,
+        "block": 5,
         "slug": "st22_lucky",
         "name": "Advanced Deck Amethyst Mandala [ST-22] - Lucky Deck",
         "release": "December 5, 2025",
@@ -2429,6 +2615,7 @@ const data2025 = [
             "LM-029": "",
         },
         "reprint": true,
+        "block": 5,
         "info_url": "https://world.digimoncard.com/products/deck/st-22/"
     },
 
@@ -2436,10 +2623,11 @@ const data2025 = [
     // Playmat & Card Set Paildramon & Dinobeemon --- bcgfest_25_26_playmat
     {
         "id": null,
+        "block": 4,
         "slug": "bcgfest_25_26_playmat",
         "name": "Playmat & Card Set Paildramon & Dinobeemon",
         "release": "December 13, 2025",
-        "url": "noCardURL",
+        "url": "bandaitcgplusURL/P/e_setID-cardID_2_D.png",
         "cards": {
             "BT20-016": "",
             "BT20-074": "",
@@ -2449,10 +2637,14 @@ const data2025 = [
     // Championship 25-26 Finals Season 2 Tamers Pack/Set --- championship_2526_finals_2_tamers
     {
         "id": null,
+        "block": {
+            "4": ["EX8","ST18"],
+            "5": ["BT21","EX9"]
+        },
         "slug": "championship_2526_finals_2_tamers",
         "name": "Championship 25-26 Finals Season 2 Tamers Pack/Set",
         "release": "December 13-14, 2025",
-        "url": "bandaitcgplusURL/P/e_setID-cardIDCS_D.png",
+        "url": "bandaitcgplusURL/P/e_setID-cardIDPR_D.png",
         "cards": {
             "BT21-025": "",
             "BT21-036": "",
@@ -2466,6 +2658,7 @@ const data2025 = [
     // Championship 25-26 Finals Season 2 - Top 32 --- championship_2526_finals_2_top32
     {
         "id": null,
+        "block": 4,
         "slug": "championship_2526_finals_2_top32",
         "name": "Championship 25-26 Finals Season 2 - Top 32",
         "release": "December 13-14, 2025",
@@ -2478,6 +2671,7 @@ const data2025 = [
     // Championship 25-26 Finals Season 2 - Top 16 --- championship_2526_finals_2_top16
     {
         "id": null,
+        "block": 4,
         "slug": "championship_2526_finals_2_top16",
         "name": "Championship 25-26 Finals Season 2 - Top 16",
         "release": "December 13-14, 2025",
@@ -2490,6 +2684,7 @@ const data2025 = [
     // Championship 25-26 Finals Season 2 - 3rd Place --- championship_2526_finals_2_3rd
     {
         "id": null,
+        "block": 4,
         "slug": "championship_2526_finals_2_3rd",
         "name": "Championship 25-26 Finals Season 2 - 3rd Place",
         "release": "December 13-14, 2025",
@@ -2502,6 +2697,7 @@ const data2025 = [
     // Championship 25-26 Finals Season 2 - 2nd Place --- championship_2526_finals_2_2nd
     {
         "id": null,
+        "block": 4,
         "slug": "championship_2526_finals_2_2nd",
         "name": "Championship 25-26 Finals Season 2 - 2nd Place",
         "release": "December 13-14, 2025",
@@ -2514,6 +2710,7 @@ const data2025 = [
     // Championship 25-26 Finals Season 2 - 1st Place --- championship_2526_finals_2_1st
     {
         "id": null,
+        "block": 4,
         "slug": "championship_2526_finals_2_1st",
         "name": "Championship 25-26 Finals Season 2 - 1st Place",
         "release": "December 13-14, 2025",

--- a/js/data/data_2025.js
+++ b/js/data/data_2025.js
@@ -1846,6 +1846,7 @@ const data2025 = [
             }
         },
         "info_url": "https://world.digimoncard.com/event/2025/gamescom/"
+        // https://world.digimoncard.com/event/2025/learn-to-play/
     },
 
 // September 1 – October 31, 2025

--- a/js/data/data_2026.js
+++ b/js/data/data_2026.js
@@ -3,6 +3,12 @@ const data2026 = [
     // TAMER'S EVOLUTION BOX - RISE OF DIGIMON [PB-21] --- pb21
     {
         "id": null,
+        "block": {
+            "1": ["BT9"],
+            "2": ["BT5","BT10","BT11"],
+            "3": ["BT16","EX5","EX6"],
+            "4": ["BT18","EX7","EX8"]
+        },
         "slug": "pb21",
         "name": "TAMER'S EVOLUTION BOX - RISE OF DIGIMON [PB-21]",
         "release": "January 2026",
@@ -28,6 +34,7 @@ const data2026 = [
     // Official Store Tournament 2026 Vol.1 - Participation Pack --- otp20
     {
         "id": null,
+        "block": 5,
         "slug": "otp20",
         "name": "Official Store Tournament 2026 Vol.1 - Participation Pack",
         "release": "January 1 – March 31, 2026",
@@ -46,6 +53,7 @@ const data2026 = [
     // Official Store Tournament 2026 Vol.1 - Winner Pack --- wp20
     {
         "id": null,
+        "block": 5,
         "slug": "wp20",
         "name": "Official Store Tournament 2026 Vol.1 - Winner Pack",
         "release": "January 1 – March 31, 2026",
@@ -65,6 +73,10 @@ const data2026 = [
     // Regulation Battle Vol.4 --- rb_4
     {
         "id": null,
+        "block": {
+            "4": ["EX7"],
+            "5": ["BT22"]
+        },
         "slug": "rb_4",
         "name": "Regulation Battle Vol.4",
         "release": "January 1 – February 28, 2026",
@@ -80,6 +92,7 @@ const data2026 = [
     // 2026 Dash Pack Campaign - 2026_dashpack
     {
         "id": null,
+        "block": 5,
         "slug": "2026_dashpack",
         "name": "2026 Dash Pack Campaign",
         "release": "January 16, 2026",
@@ -96,6 +109,7 @@ const data2026 = [
     // TIME STRANGER [BT-24] Release Event --- bt24_prerelease
     {
         "id": null,
+        "block": 3,
         "slug": "bt24_prerelease",
         "name": "TIME STRANGER [BT-24] Release Event",
         "release": "January 16 - 22, 2026",
@@ -110,6 +124,7 @@ const data2026 = [
     // Booster Time Stranger [BT-24] --- bt24
     {
         "id": "BT24",
+        "block": 5,
         "slug": "bt24",
         "name": "Booster Time Stranger [BT-24]",
         "release": "January 23, 2026",
@@ -148,7 +163,7 @@ const data2026 = [
             "white": [100,102]
         },
         "rarity": {
-            "c": ["1-7","9-11",15,19,21,22,32,33,35,36,39,42,43,46,47,49,50,"52-55",57,61,63,66,"68-70",73,76,90,99],
+            "c": ["1-7","9-11",15,19,21,22,32,33,35,36,39,42,43,46,47,49,50,"52-55",57,60,61,63,66,"68-70",73,76,90,99],
             "u": [8,12,13,16,20,23,24,26,29,38,44,45,58,67,72,74,75,88,89,"91-95",97,98],
             "r": [14,17,25,27,28,31,37,48,56,59,62,64,71,74,77,80,82,83,86,87,96,100],
             "sr": [18,30,34,40,41,51,65,78,79,81,84,85],
@@ -159,6 +174,7 @@ const data2026 = [
     // Booster Time Stranger [BT-24] - Alternatives --- bt24_alts
     {
         "id": null,
+        "block": 5,
         "slug": "bt24_alts",
         "name": "Booster Time Stranger [BT-24] - Alternatives",
         "release": "January 23, 2026",
@@ -190,6 +206,7 @@ const data2026 = [
     // Booster Time Stranger [BT-24] - Special Cards --- bt24_special
     {
         "id": null,
+        "block": 5,
         "slug": "bt24_special",
         "name": "Booster Time Stranger [BT-24] - Special Cards",
         "release": "January 23, 2026",
@@ -206,6 +223,7 @@ const data2026 = [
     // Booster Time Stranger [BT-24] - Box Promotion Pack --- bt24_boxtopper
     {
         "id": null,
+        "block": 5,
         "slug": "bt24_boxtopper",
         "name": "Booster Time Stranger [BT-24] - Box Promotion Pack",
         "release": "January 23, 2026",
@@ -237,10 +255,14 @@ const data2026 = [
     // Digimon Liberator Debuggers Set [pb22] --- pb22
     {
         "id": null,
+        "block": {
+            "4": ["P","ST18","ST19","EX7","BT19","EX8","BT20"],
+            "5": ["BT21","EX9"]
+        },
         "slug": "pb22",
         "name": "Digimon Liberator Debuggers Set [PB-22]",
         "release": "February 2026",
-        "url": "noCardURL",
+        "url": "bandaitcgplusURL/PB22/e_PB22_setID-cardID_d.png",
         "cards": {
             "ST18-12": "",
             "ST18-14": "",
@@ -269,6 +291,17 @@ const data2026 = [
             "BT21-081": "",
             "P-151": "",
         },
+        "override": {
+            "url": "bandaitcgplusURL/PB22/e_setID-cardID_D.png",
+            "cards": {
+                "ST18-12": "",
+                "EX7-030": "",
+                "EX8-055": "",
+                "BT19-027": "",
+                "BT20-079": "",
+                "BT21-029": "",
+            }
+        },
         "info_url": "https://world.digimoncard.com/products/goods/liberator-debuggers-set.php"
     },
 
@@ -276,6 +309,7 @@ const data2026 = [
     // Extra Booster Dawn Of Liberator [EX11] --- ex11
     {
         "id": "EX11",
+        "block": 5,
         "slug": "ex11",
         "name": "Extra Booster Dawn Of Liberator [EX11]",
         "release": "February 13, 2026",
@@ -305,6 +339,7 @@ const data2026 = [
     // Extra Booster Dawn Of Liberator [EX11] - Alternatives --- ex11_alts
     {
         "id": null,
+        "block": 5,
         "slug": "ex11_alts",
         "name": "Extra Booster Dawn Of Liberator [EX11] - Alternatives",
         "release": "February 13, 2026",
@@ -336,6 +371,7 @@ const data2026 = [
     // Extra Booster Dawn Of Liberator [EX11] - Limited Cards --- ex11_limited
     {
         "id": null,
+        "block": 5,
         "slug": "ex11_limited",
         "name": "Extra Booster Dawn Of Liberator [EX11] - Limited Cards",
         "release": "February 13, 2026",
@@ -382,6 +418,7 @@ const data2026 = [
     // Extra Booster Dawn Of Liberator [EX11] - Special Cards --- ex11_special
     {
         "id": null,
+        "block": 5,
         "slug": "ex11_special",
         "name": "Extra Booster Dawn Of Liberator [EX11] - Special Cards",
         "release": "February 13, 2026",
@@ -400,6 +437,10 @@ const data2026 = [
     // Extra Booster Dawn Of Liberator [EX11] - Special Edition Cards --- ex11_special_edition
     {
         "id": null,
+        "block": {
+            "4": ["BT18","BT20","ST18","ST19"],
+            "5": ["BT21","BT23","EX11"]
+        },
         "slug": "ex11_special_edition",
         "name": "Extra Booster Dawn Of Liberator [EX11] - Special Edition Cards",
         "release": "February 13, 2026",
@@ -426,6 +467,7 @@ const data2026 = [
     // Extra Booster Dawn Of Liberator [EX11] - Box Promotion Pack --- ex11_boxtopper
     {
         "id": null,
+        "block": 5,
         "slug": "ex11_boxtopper",
         "name": "Extra Booster Dawn Of Liberator [EX11] - Box Promotion Pack",
         "release": "February 13, 2026",
@@ -457,6 +499,7 @@ const data2026 = [
     // ADVANCED BOOSTER DIGIMON GENERATION [AD-01] - ad1
     {
         "id": "AD1",
+        "block": 5,
         "slug": "ad1",
         "name": "ADVANCED BOOSTER DIGIMON GENERATION [AD-01]",
         "release": "March 27, 2026",
@@ -492,6 +535,7 @@ const data2026 = [
     // ADVANCED BOOSTER DIGIMON GENERATION [AD-01] - Alternatives --- ad1_alts
     {
         "id": null,
+        "block": 5,
         "slug": "ad1_alts",
         "name": "ADVANCED BOOSTER DIGIMON GENERATION [AD-01] - Alternatives",
         "release": "March 27, 2026",
@@ -522,6 +566,7 @@ const data2026 = [
     // ADVANCED BOOSTER DIGIMON GENERATION [AD-01] - Special Cards --- ad1_special
     {
         "id": null,
+        "block": 5,
         "slug": "ad1_special",
         "name": "ADVANCED BOOSTER DIGIMON GENERATION [AD-01] - Special Cards",
         "release": "March 27, 2026",
@@ -702,10 +747,12 @@ const data2026 = [
             }
         },
         "reprint": true,
+        "block": 5,
     },
     // ADVANCED BOOSTER DIGIMON GENERATION [AD-01] - Reprints --- ad1_reprints
     {
         "id": null,
+        "block": 5,
         "slug": "ad1_reprints",
         "name": "ADVANCED BOOSTER DIGIMON GENERATION [AD-01] - Reprints",
         "release": "March 27, 2026",
@@ -745,6 +792,8 @@ const data2026 = [
         "slug": "ad1_alt_reprints",
         "name": "ADVANCED BOOSTER DIGIMON GENERATION [AD-01] - Alternative Reprints",
         "release": "March 27, 2026",
+        "reprint": true,
+        "block": 5,
         "url": "bandaitcgplusURL/AD01/e_setID-cardIDparallel.png",
         "cards": {
             "BT12-022": "P_d",
@@ -761,6 +810,7 @@ const data2026 = [
     // ADVANCED BOOSTER DIGIMON GENERATION [AD-01] - Gold Foil --- ad1_gold_foil
     {
         "id": null,
+        "block": 5,
         "slug": "ad1_gold_foil",
         "name": "ADVANCED BOOSTER DIGIMON GENERATION [AD-01] - Gold Foil",
         "release": "March 27, 2026",
@@ -841,10 +891,15 @@ const data2026 = [
     // Event Pack 9 --- eventpack9
     {
         "id": null,
+        "block": {
+            "1": ["ST10"],
+            "2": ["BT11"],
+            "5": ["ST21","BT21","EX9","BT23"]
+        },
         "slug": "eventpack9",
         "name": "Event Pack 9",
         "release": "March 28-29, 2026",
-        "url": "noCardURL",
+        "url": "bandaitcgplusURL/P/e_setID-cardIDEP_D.png",
         "cards": {
             "BT11-069": "",
             "BT21-013": "",
@@ -867,6 +922,7 @@ const data2026 = [
     // Limited Card Pack ANOTHER KNIGHT --- lm07
     {
         "id": null,
+        "block": 5,
         "slug": "lm07",
         "name": "Limited Card Pack ANOTHER KNIGHT",
         "release": "March 2026",
@@ -884,6 +940,11 @@ const data2026 = [
     // Limited Card Pack ANOTHER KNIGHT - Alternatives --- lm07_alts
     {
         "id": null,
+        "block": {
+            "2": ["EX4","BT13"],
+            "3": ["BT16"],
+            "5": ["BT21"]
+        },
         "slug": "lm07_alts",
         "name": "Limited Card Pack ANOTHER KNIGHT - Alternatives",
         "release": "March 2026",
@@ -899,6 +960,12 @@ const data2026 = [
     // Limited Card Pack ANOTHER KNIGHT - Reprints --- lm07_reprints
     {
         "id": null,
+        "block": {
+            "2": ["P-092","BT10"],
+            "3": ["EX6"],
+            "4": ["BT20","P-133","P-136"],
+            "5": ["BT21","P"]
+        },
         "slug": "lm07_reprints",
         "name": "Limited Card Pack ANOTHER KNIGHT - Reprints",
         "release": "March 2026",
@@ -944,24 +1011,30 @@ const data2026 = [
     // Premium Heroines Set ver.2 [PB-23] --- pb23
     {
         "id": null,
+        "block": {
+            "1": ["BT8","ST10"],
+            "2": ["BT5","BT11","BT13","EX3","ST14"],
+            "3": ["EX5","EX6"],
+            "4": ["LM","ST19"]
+        },
         "slug": "pb23",
         "name": "Premium Heroines Set ver.2 [PB-23]",
         "release": "January 2026",
-        "url": "noCardURL",
+        "url": "bandaitcgplusURL/PB23/parallel_setID-cardID.png",
         "cards": {
-            "BT5-092": "",
-            "BT8-082": "",
-            "BT11-089": "",
-            "BT11-112": "",
-            "BT13-057": "",
-            "EX3-065": "",
-            "EX5-025": "",
-            "EX6-074": "",
-            "P-195": "",
-            "LM-042": "",
-            "ST10-06": "",
-            "ST14-09": "",
-            "ST19-12": "",
+            "BT5-092": "Same",
+            "BT8-082": "Same",
+            "BT11-089": "Same",
+            "BT11-112": "Same",
+            "BT13-057": "Same",
+            "EX3-065": "e",
+            "EX5-025": "Same",
+            "EX6-074": "Same",
+            "P-195": "Same",
+            "LM-042": "Same",
+            "ST10-06": "Same",
+            "ST14-09": "Same",
+            "ST19-12": "Same",
         },
         "info_url": "https://world.digimoncard.com/products/goods/premium-heroines-set-02.php"
     },
@@ -970,6 +1043,7 @@ const data2026 = [
     // Limited Card Pack FINAL CREST --- lm08
     {
         "id": null,
+        "block": 6,
         "slug": "lm08",
         "name": "Limited Card Pack FINAL CREST",
         "release": "August 2026",
@@ -987,6 +1061,10 @@ const data2026 = [
     // Limited Card Pack FINAL CREST - Alternatives --- lm08_alts
     {
         "id": null,
+        "block": {
+            "4": ["BT20","EX8"],
+            "5": ["BT22"]
+        },
         "slug": "lm08_alts",
         "name": "Limited Card Pack FINAL CREST - Alternatives",
         "release": "August 2026",
@@ -1004,6 +1082,7 @@ const data2026 = [
         "id": null,
         "slug": "lm08_reprints",
         "name": "Limited Card Pack FINAL CREST - Reprints",
+        // TODO: revisar block
         "release": "August 2026",
         "url": "noCardURL",
         "cards": {

--- a/js/data/data_2026.js
+++ b/js/data/data_2026.js
@@ -30,6 +30,25 @@ const data2026 = [
         "info_url": "https://world.digimoncard.com/products/goods/tamers-evolution-box/"
     },
 
+// January 1 – February 28, 2026
+    // Regulation Battle Vol.4 --- rb_4
+    {
+        "id": null,
+        "block": {
+            "4": ["EX7"],
+            "5": ["BT22"]
+        },
+        "slug": "rb_4",
+        "name": "Regulation Battle Vol.4",
+        "release": "January 1 – February 28, 2026",
+        "url": "bandaitcgplusURL/P/e_setID-cardID_D.png",
+        "cards": {
+            "BT22-069": "",
+            "EX7-021": "",
+        },
+        "info_url": "https://world.digimoncard.com/event/2025/regulation_battle-04/",
+    },
+
 // January 1 – March 31, 2026
     // Official Store Tournament 2026 Vol.1 - Participation Pack --- otp20
     {
@@ -67,25 +86,6 @@ const data2026 = [
             "P-219": "",
         },
         "info_url": "https://world.digimoncard.com/event/2026/store-tournament/01/",
-    },
-
-// January 1 – February 28, 2026
-    // Regulation Battle Vol.4 --- rb_4
-    {
-        "id": null,
-        "block": {
-            "4": ["EX7"],
-            "5": ["BT22"]
-        },
-        "slug": "rb_4",
-        "name": "Regulation Battle Vol.4",
-        "release": "January 1 – February 28, 2026",
-        "url": "bandaitcgplusURL/P/e_setID-cardID_D.png",
-        "cards": {
-            "BT22-069": "",
-            "EX7-021": "",
-        },
-        "info_url": "https://world.digimoncard.com/event/2025/regulation_battle-03/",
     },
 
 // January 16, 2026
@@ -493,6 +493,223 @@ const data2026 = [
             "P": "p"
         },
         "info_url": "https://world.digimoncard.com/products/pack/ver22/",
+    },
+
+// March 2026
+    // Limited Card Pack ANOTHER KNIGHT --- lm07
+    {
+        "id": null,
+        "block": 5,
+        "slug": "lm07",
+        "name": "Limited Card Pack ANOTHER KNIGHT",
+        "release": "March 2026",
+        "url": "bandaitcgplusURL/LM07/e_LM07-setID-cardID_d.png",
+        "cards": {
+            "LM-051": "",
+            "LM-052": "",
+            "LM-053": "",
+            "LM-054": "",
+            "LM-055": "",
+            "LM-056": "",
+        },
+        "info_url": "https://world.digimoncard.com/products/goods/limited-lm-07.php"
+    },
+    // Limited Card Pack ANOTHER KNIGHT - Alternatives --- lm07_alts
+    {
+        "id": null,
+        "block": {
+            "2": ["EX4","BT13"],
+            "3": ["BT16"],
+            "5": ["BT21"]
+        },
+        "slug": "lm07_alts",
+        "name": "Limited Card Pack ANOTHER KNIGHT - Alternatives",
+        "release": "March 2026",
+        "url": "bandaitcgplusURL/LM07/e_LM07-setID-cardID_d.png",
+        "cards": {
+            "BT13-112": "",
+            "BT16-077": "",
+            "BT21-097": "",
+            "EX4-073": "",
+        },
+        "info_url": "https://world.digimoncard.com/products/goods/limited-lm-07.php"
+    },
+    // Limited Card Pack ANOTHER KNIGHT - Reprints --- lm07_reprints
+    {
+        "id": null,
+        "block": {
+            "2": ["P-092","BT10"],
+            "3": ["EX6"],
+            "4": ["BT20","P-133","P-136"],
+            "5": ["BT21","P"]
+        },
+        "slug": "lm07_reprints",
+        "name": "Limited Card Pack ANOTHER KNIGHT - Reprints",
+        "release": "March 2026",
+        "url": "bandaitcgplusURL/LM07/e_setID-cardID_D.png",
+        "cards": {
+            "BT10-093": "",
+            "BT20-014": "",
+            "BT20-026": "",
+            "BT21-005": "",
+            "BT21-017": "",
+            "BT21-095": "",
+            "EX6-029": "",
+            "EX6-043": "",
+            "P-092": "",
+            "P-133": "",
+            "P-136": "",
+            "P-188": "",
+            "P-189": "",
+            "P-190": "",
+            "P-191": "",
+            "P-192": "",
+            "P-193": "",
+        },
+        "info_url": "https://world.digimoncard.com/products/goods/limited-lm-07.php"
+    },
+    {
+        "id": null,
+        "slug": "lm07_reprints",
+        "name": "Limited Card Pack ANOTHER KNIGHT - Reprints",
+        "release": "March 2026",
+        "url": "bandaitcgplusURL/LM07/e_LM07-setID-cardID_d.png",
+        "cards": {
+            "P-176": "",
+            "P-177": "",
+            "P-178": "",
+            "P-179": "",
+            "P-180": "",
+            "P-181": "",
+        },
+        "info_url": "https://world.digimoncard.com/products/goods/limited-lm-07.php"
+    },
+
+    // Premium Heroines Set ver.2 [PB-23] --- pb23
+    {
+        "id": null,
+        "block": {
+            "1": ["BT8","ST10"],
+            "2": ["BT5","BT11","BT13","EX3","ST14"],
+            "3": ["EX5","EX6"],
+            "4": ["LM","ST19"]
+        },
+        "slug": "pb23",
+        "name": "Premium Heroines Set ver.2 [PB-23]",
+        "release": "March 2026",
+        "url": "bandaitcgplusURL/PB23/parallel_setID-cardID.png",
+        "cards": {
+            "BT5-092": "Same",
+            "BT8-082": "Same",
+            "BT11-089": "Same",
+            "BT11-112": "Same",
+            "BT13-057": "Same",
+            "EX3-065": "e",
+            "EX5-025": "Same",
+            "EX6-074": "Same",
+            "P-195": "Same",
+            "LM-042": "Same",
+            "ST10-06": "Same",
+            "ST14-09": "Same",
+            "ST19-12": "Same",
+        },
+        "info_url": "https://world.digimoncard.com/products/goods/premium-heroines-set-02.php"
+    },
+
+// March 1 – April 30, 2026
+    // Evolution Cup 2026 Vol.1 Participation --- evolution_cup_2026_1_participant
+    {
+        "id": null,
+        "block": 5,
+        "slug": "evolution_cup_2026_1_participant",
+        "name": "Evolution Cup 2026 Vol.1 Participation",
+        "release": "March 1 – April 30, 2026",
+        "url": "bandaitcgplusURL/P/e_setID-cardID_D.png",
+        "cards": {
+            "BT21-060": "",
+        },
+        "info_url": "https://world.digimoncard.com/event/2026/evolution-cup/01/",
+    },
+    // Evolution Cup 2026 Vol.1 Top 4 --- evolution_cup_2026_1_top4
+    {
+        "id": null,
+        "block": 5,
+        "slug": "evolution_cup_2026_1_top4",
+        "name": "Evolution Cup 2026 Vol.1 Top 4",
+        "release": "March 1 – April 30, 2026",
+        "url": "bandaitcgplusURL/P/e_setID-cardID_D.png",
+        "cards": {
+            "BT21-098": "",
+        },
+        "info_url": "https://world.digimoncard.com/event/2026/evolution-cup/01/",
+    },
+    // Evolution Cup 2026 Vol.1 Winner --- evolution_cup_2026_1_winner
+    {
+        "id": null,
+        "block": 4,
+        "slug": "evolution_cup_2026_1_winner",
+        "name": "Evolution Cup 2026 Vol.1 Winner",
+        "release": "March 1 – April 30, 2026",
+        "url": "bandaitcgplusURL/P/e_setID-cardID_D.png",
+        "cards": {
+            "BT18-092": "",
+        },
+        "info_url": "https://world.digimoncard.com/event/2026/evolution-cup/01/",
+    },
+
+// March 15, 2026
+    // 25-26 World Championship - Participation --- wc2025
+    {
+        "id": null,
+        "block": 3,
+        "slug": "wc2025",
+        "name": "25-26 World Championship - Participation",
+        "release": "March 15, 2026",
+        "url": null,
+        "cards": {
+            "BT17-101": "https://world.digimoncard.com/images/event/2025/championship/world-final/participation.png",
+        },
+        "playmat": "https://world.digimoncard.com/images/event/2025/championship/world-final/playmat.png",
+        "info_url": "https://world.digimoncard.com/event/2025/championship/world-final/"
+    },
+    // 25-26 World Championship - 3rd Place Prize --- wc2025_3rd
+    {
+        "id": null,
+        "block": 3,
+        "slug": "wc2025_3rd",
+        "name": "25-26 World Championship - 3rd Place Prize",
+        "release": "March 15, 2026",
+        "url": null,
+        "cards": {
+            "BT17-101": "https://world.digimoncard.com/images/event/2025/championship/world-final/3rd.png",
+        },
+        "info_url": "https://world.digimoncard.com/event/2025/championship/world-final/"
+    },
+    // 25-26 World Championship - Runner-Up Prize --- wc2025_2nd
+    {
+        "id": null,
+        "block": 3,
+        "slug": "wc2025_2nd",
+        "name": "25-26 World Championship - Runner-Up Prize",
+        "release": "March 15, 2026",
+        "url": null,
+        "cards": {
+            "BT17-101": "https://world.digimoncard.com/images/event/2025/championship/world-final/2nd.png",
+        },
+        "info_url": "https://world.digimoncard.com/event/2025/championship/world-final/"
+    },
+    // 25-26 World Championship - Champion Prize --- wc2025_1st
+    {
+        "id": null,
+        "block": 3,
+        "slug": "wc2025_1st",
+        "name": "25-26 World Championship - Champion Prize",
+        "release": "March 15, 2026",
+        "url": null,
+        "cards": {
+            "BT17-101": "https://world.digimoncard.com/images/event/2025/championship/world-final/1st.png",
+        },
+        "info_url": "https://world.digimoncard.com/event/2025/championship/world-final/"
     },
 
 // March 27, 2026
@@ -910,133 +1127,574 @@ const data2026 = [
         },
         "info_url": "https://world.digimoncard.com/event/2026/championship/regionals-season1/"
     },
-    // Regionals 26-27 Season 1 Participation Card Set
-    // Regionals 26-27 Season 1 Finalist Card Set
-    // Regionals 26-27 Season 1 Champion Card Set
-    // Regionals 26-27 Promotion Card Participant: Koromon
-    // Regionals 26-27 Promotion Card Top 64: Agumon
-    // Regionals 26-27 Promotion Card Top 16: Greymon
-    // Regionals 26-27 Promotion Card Top 2: MetalGreymon
-
-// March 2026
-    // Limited Card Pack ANOTHER KNIGHT --- lm07
+    // Regionals 26-27 Season 1 Participation Card Set --- regional2627_1_0
+    {
+        "id": null,
+        "block": {
+            "3": ["EX5"],
+            "4": ["BT20"],
+            "5": ["BT22","ST22","P"]
+        },
+        "slug": "regional2627_1_0",
+        "name": "Regionals 26-27 Season 1 Participation Card Set",
+        "release": "March 28-29, 2026",
+        "url": "bandaitcgplusURL/P/e_setID-cardID_parti_D.png",
+        "cards": {
+            "BT20-072": "",
+            "BT22-064": "",
+            "BT22-073": "",
+            "EX5-001": "",
+            "ST22-06": "",
+            "P-209": "",
+        },
+        "info_url": "https://world.digimoncard.com/event/2026/championship/regionals-season1/"
+    },
+    // Regionals 26-27 Season 1 Finalist Card Set --- regional2627_1_1
+    {
+        "id": null,
+        "block": {
+            "3": ["EX5"],
+            "4": ["BT20"],
+            "5": ["BT22","ST22","P"]
+        },
+        "slug": "regional2627_1_1",
+        "name": "Regionals 26-27 Season 1 Finalist Card Set",
+        "release": "March 28-29, 2026",
+        "url": "bandaitcgplusURL/P/e_setID-cardID_fina_D.png",
+        // TODO: sleeve: "https://world.digimoncard.com/images/event/2026/championship/regionals-season1/popup/img_sleeve01.png",
+        "cards": {
+            "BT20-072": "",
+            "BT22-064": "",
+            "BT22-073": "",
+            "EX5-001": "",
+            "ST22-06": "",
+            "P-209": "",
+        },
+        "info_url": "https://world.digimoncard.com/event/2026/championship/regionals-season1/"
+    },
+    // Regionals 26-27 Season 1 Champion Card Set --- regional2627_1_2
+    {
+        "id": null,
+        "block": {
+            "3": ["EX5"],
+            "4": ["BT20"],
+            "5": ["BT22","ST22","P"]
+        },
+        "slug": "regional2627_1_2",
+        "name": "Regionals 26-27 Season 1 Champion Card Set",
+        "release": "March 28-29, 2026",
+        "url": "bandaitcgplusURL/P/e_setID-cardID_camp_D.png",
+        // TODO: playmat: "https://world.digimoncard.com/images/event/2026/championship/regionals-season1/popup/img_playmat01.png",
+        "cards": {
+            "BT20-072": "",
+            "BT22-064": "",
+            "BT22-073": "",
+            "EX5-001": "",
+            "ST22-06": "",
+            "P-209": "",
+        },
+        "info_url": "https://world.digimoncard.com/event/2026/championship/regionals-season1/"
+    },
+    // Regionals 26-27 Promotion Card Participant: Koromon --- regional2627_1_promo_participant
     {
         "id": null,
         "block": 5,
-        "slug": "lm07",
-        "name": "Limited Card Pack ANOTHER KNIGHT",
-        "release": "March 2026",
-        "url": "bandaitcgplusURL/LM07/e_LM07-setID-cardID_d.png",
+        "slug": "regional2627_1_promo_participant",
+        "name": "Regionals 26-27 Promotion Card Participant: Koromon",
+        "release": "March 28-29, 2026",
+        "url": "bandaitcgplusURL/P/e_setID-cardID_D.png",
         "cards": {
-            "LM-051": "",
-            "LM-052": "",
-            "LM-053": "",
-            "LM-054": "",
-            "LM-055": "",
-            "LM-056": "",
+            "ST20-01": "",
         },
-        "info_url": "https://world.digimoncard.com/products/goods/limited-lm-07.php"
+        "info_url": "https://world.digimoncard.com/event/2026/championship/regionals-season1/"
     },
-    // Limited Card Pack ANOTHER KNIGHT - Alternatives --- lm07_alts
+    // Regionals 26-27 Promotion Card Top 64: Agumon --- regional2627_1_promo_top64
     {
         "id": null,
-        "block": {
-            "2": ["EX4","BT13"],
-            "3": ["BT16"],
-            "5": ["BT21"]
-        },
-        "slug": "lm07_alts",
-        "name": "Limited Card Pack ANOTHER KNIGHT - Alternatives",
-        "release": "March 2026",
-        "url": "bandaitcgplusURL/LM07/e_LM07-setID-cardID_d.png",
+        "block": 5,
+        "slug": "regional2627_1_promo_top64",
+        "name": "Regionals 26-27 Promotion Card Top 64: Agumon",
+        "release": "March 28-29, 2026",
+        "url": "bandaitcgplusURL/P/e_setID-cardID_D.png",
         "cards": {
-            "BT13-112": "",
-            "BT16-077": "",
-            "BT21-097": "",
-            "EX4-073": "",
+            "ST20-10": "",
         },
-        "info_url": "https://world.digimoncard.com/products/goods/limited-lm-07.php"
+        "info_url": "https://world.digimoncard.com/event/2026/championship/regionals-season1/"
     },
-    // Limited Card Pack ANOTHER KNIGHT - Reprints --- lm07_reprints
+    // Regionals 26-27 Promotion Card Top 16: Greymon --- regional2627_1_promo_top16
     {
         "id": null,
-        "block": {
-            "2": ["P-092","BT10"],
-            "3": ["EX6"],
-            "4": ["BT20","P-133","P-136"],
-            "5": ["BT21","P"]
-        },
-        "slug": "lm07_reprints",
-        "name": "Limited Card Pack ANOTHER KNIGHT - Reprints",
-        "release": "March 2026",
-        "url": "bandaitcgplusURL/LM07/e_setID-cardID_D.png",
+        "block": 5,
+        "slug": "regional2627_1_promo_top16",
+        "name": "Regionals 26-27 Promotion Card Top 16: Greymon",
+        "release": "March 28-29, 2026",
+        "url": "bandaitcgplusURL/P/e_setID-cardID_D.png",
         "cards": {
-            "BT10-093": "",
-            "BT20-014": "",
-            "BT20-026": "",
-            "BT21-005": "",
-            "BT21-017": "",
-            "BT21-095": "",
-            "EX6-029": "",
-            "EX6-043": "",
-            "P-092": "",
-            "P-133": "",
-            "P-136": "",
-            "P-188": "",
-            "P-189": "",
-            "P-190": "",
-            "P-191": "",
-            "P-192": "",
-            "P-193": "",
+            "AD1-001": "",
         },
-        "info_url": "https://world.digimoncard.com/products/goods/limited-lm-07.php"
+        "info_url": "https://world.digimoncard.com/event/2026/championship/regionals-season1/"
     },
+    // Regionals 26-27 Promotion Card Top 2: MetalGreymon --- regional2627_1_promo_top2
     {
         "id": null,
-        "slug": "lm07_reprints",
-        "name": "Limited Card Pack ANOTHER KNIGHT - Reprints",
-        "release": "March 2026",
-        "url": "bandaitcgplusURL/LM07/e_LM07-setID-cardID_d.png",
+        "block": 5,
+        "slug": "regional2627_1_promo_top2",
+        "name": "Regionals 26-27 Promotion Card Top 2: MetalGreymon",
+        "release": "March 28-29, 2026",
+        "url": "bandaitcgplusURL/P/e_setID-cardID_D.png",
         "cards": {
-            "P-176": "",
-            "P-177": "",
-            "P-178": "",
-            "P-179": "",
-            "P-180": "",
-            "P-181": "",
+            "BT21-061": "",
         },
-        "info_url": "https://world.digimoncard.com/products/goods/limited-lm-07.php"
+        "info_url": "https://world.digimoncard.com/event/2026/championship/regionals-season1/"
+    },
+    // Ultimate Cup 26-27 Season 1 --- ultimatecup_2026_1
+    {
+        "id": null,
+        "block": 5,
+        "slug": "ultimatecup_2026_1",
+        "name": "Ultimate Cup 26-27 Season 1",
+        "release": "March 28-29, 2026",
+        "url": "bandaitcgplusURL/P/e_setID-cardID_D.png",
+        "cards": {
+            "RB1-001": "", // Participation
+            "RB1-005": "", // Top 16
+            "BT21-022": "", // Top 4
+            "BT21-028": "", // Champion
+        },
+        "info_url": "https://world.digimoncard.com/event/2026/ultimate-cup/season1/"
     },
 
-    // Premium Heroines Set ver.2 [PB-23] --- pb23
+// April 1 – June 30, 2026
+    // Official Store Tournament 2026 Vol.2 - Participation Pack --- otp21
+    {
+        "id": null,
+        "block": 6,
+        "slug": "otp21",
+        "name": "Official Store Tournament 2026 Vol.2 - Participation Pack",
+        "release": "April 1 – June 30, 2026",
+        "url": "bandaitcgplusURL/P/e_setID-cardID_D.png",
+        "cards": {
+            "P-233": "",
+            "P-234": "",
+            "P-235": "",
+            "P-236": "",
+            "P-237": "",
+            "P-238": "",
+        },
+        "rarity": "p",
+        "info_url": "https://world.digimoncard.com/event/2026/store-tournament/02/",
+    },
+    // Judge Pack 9 --- judgepack9
+    {
+        "id": null,
+        "block": 5,
+        "slug": "judgepack9",
+        "name": "Judge Pack 9",
+        "release": "April 1 – June 30, 2026",
+        "url": "bandaitcgplusURL/P/e_setID-cardIDJP_D.png",
+        "cards": {
+            "BT22-024": "",
+            "BT22-036": "",
+            "BT23-065": "",
+            "BT24-016": "",
+            "BT24-075": "",
+            "BT24-090": "",
+            "BT24-093": "",
+            "BT24-094": "",
+            "EX10-032": "",
+            "EX11-032": "",
+        },
+        "info_url": "https://world.digimoncard.com/event/2026/store-tournament/02/",
+    },
+    // Official Store Tournament 2026 Vol.2 - Winner Pack --- wp21
+    {
+        "id": null,
+        "block": 6,
+        "slug": "wp21",
+        "name": "Official Store Tournament 2026 Vol.2 - Winner Pack",
+        "release": "April 1 – June 30, 2026",
+        "url": "bandaitcgplusURL/P/e_setID-cardIDP_D.png",
+        "cards": {
+            "P-233": "",
+            "P-234": "",
+            "P-235": "",
+            "P-236": "",
+            "P-237": "",
+            "P-238": "",
+        },
+        "info_url": "https://world.digimoncard.com/event/2026/store-tournament/02/",
+    },
+
+// May 15, 2026
+    // Starter Deck DIGIMON BEATBREAK [ST-23] --- st23
+    {
+        "id": "ST23",
+        "block": 6,
+        "slug": "st23",
+        "name": "Starter Deck DIGIMON BEATBREAK [ST-23]",
+        "release": "May 15, 2026",
+        "total": 15,
+        "url": "bandaitcgplusURL/ST23/e_setID-cardID_D.png",
+        "add_zero": 2,
+        "color": {
+            "yellow": ["2-5"],
+            "green": [1,"6-9"],
+            "green-yellow": [13],
+            "black": [10,11],
+            "black-purple": [14],
+            "purple": [12],
+            "white": [15]
+        },
+        "rarity": {
+            "c": [1,2,10,12,15],
+            "u": [3,4,7,11,14],
+            "r": [6,8,13],
+            "sr": [5,9]
+        },
+        "info_url": "https://world.digimoncard.com/products/deck/st-23/"
+    },
+    // Starter Deck DIGIMON BEATBREAK [ST-23] - Lucky Deck --- st23_lucky
+    {
+        "id": null,
+        "block": 6,
+        "slug": "st23_lucky",
+        "name": "Starter Deck DIGIMON BEATBREAK [ST-23] - Lucky Deck",
+        "release": "May 15, 2026",
+        "url": "bandaitcgplusURL/ST23/e_setID-cardIDP.png",
+        "cards": {
+            "ST23-06": "",
+        },
+        "info_url": "https://world.digimoncard.com/products/deck/st-23/"
+    },
+    // Starter Deck DIGIMON DATA SQUAD [ST-24] --- st24
+    {
+        "id": "ST24",
+        "block": 6,
+        "slug": "st24",
+        "name": "Starter Deck DIGIMON DATA SQUAD [ST-24]",
+        "release": "May 15, 2026",
+        "total": 15,
+        "url": "bandaitcgplusURL/ST24/e_setID-cardID_D.png",
+        "add_zero": 2,
+        "color": {
+            "blue": [2,3],
+            "yellow": [1],
+            "yellow-blue": [13],
+            "yellow-red": ["4-7"],
+            "green": ["8-10"],
+            "green-red": [11],
+            "green-purple": [14],
+            "purple": [12],
+            "white": [15]
+        },
+        "rarity": {
+            "c": [1,2,8,12,15],
+            "u": [3,5,9,10,14],
+            "r": [4,6,13],
+            "sr": [7,11]
+        },
+        "info_url": "https://world.digimoncard.com/products/deck/st-24/"
+    },
+    // Starter Deck DIGIMON DATA SQUAD [ST-24] - Lucky Deck --- st24_lucky
+    {
+        "id": null,
+        "block": 6,
+        "slug": "st24_lucky",
+        "name": "Starter Deck DIGIMON DATA SQUAD [ST-24] - Lucky Deck",
+        "release": "May 15, 2026",
+        "url": "bandaitcgplusURL/ST24/e_setID-cardID_P1_D.png",
+        "cards": {
+            "ST24-04": "",
+        },
+        "info_url": "https://world.digimoncard.com/products/deck/st-24/"
+    },
+    // New Illustration Memory Boost! --- lm_memory_boost
+    {
+        "id": null,
+        "slug": "lm_memory_boost",
+        "name": "New Illustration Memory Boost!",
+        "release": "May 15, 2026",
+        "url": "bandaitcgplusURL/ST23/e_setID-cardID_D.png",
+        "cards": {
+            "LM-033": "",
+            "LM-034": "",
+            "LM-035": "",
+            "LM-036": "",
+            "LM-037": "",
+            "LM-038": "",
+        },
+        "reprint": true,
+        "block": 6,
+        "info_url": "https://world.digimoncard.com/products/deck/st-23/"
+    },
+
+// May 15 – 21, 2026
+    // Booster Dual Revolution [BT-25] Release Event --- bt25_prerelease
+    {
+        "id": null,
+        "block": 6,
+        "slug": "bt25_prerelease",
+        "name": "Booster Dual Revolution [BT-25] Release Event",
+        "release": "May 15 – 21, 2026",
+        "url": "bandaitcgplusURL/P/e_setID-cardIDparallel_D.png",
+        "cards": {
+            "ST24-07": ["P1","P2"]
+        },
+        "info_url": "https://world.digimoncard.com/event/2026/release-event/02/"
+    },
+
+// May 22, 2026
+    // Booster Dual Revolution [BT-25] --- bt25
+    {
+        "id": "BT25",
+        "block": 6,
+        "slug": "bt25",
+        "name": "Booster Dual Revolution [BT-25]",
+        "release": "May 22, 2026",
+        "total": 104,
+        "url": "bandaitcgplusURL/BT25/e_setID-cardID_D.png",
+        "add_zero": 3,
+        "playmat": "",
+        "color": {
+            "red": [1,"7-9",13,14,17,86,93],
+            "red-blue": [94,103],
+            "red-yellow": [18,104],
+            "red-green": ["10-12",15,16,20,95],
+            "red-black": [19],
+            "blue": [2,"21-24",26,87,96],
+            "blue-black": [25,27,29],
+            "blue-purple": [28],
+            "yellow": [3,"30-36",40,41,43,88,98],
+            "yellow-blue": [37],
+            "yellow-green": [39],
+            "yellow-black": [38,42],
+            "yellow-purple": [44,97],
+            "green": [4,"45-50",55,57,89,90],
+            "green-red": [52,53],
+            "green-yellow": [56,59],
+            "green-black": [51,54,58,99],
+            "green-white": [60],
+            "black": [5,61,62,"64-66",68,69,71,73,76,91,100,101],
+            "black-red": [75,102],
+            "black-green": [77],
+            "black-purple": [63,67,70,72,74],
+            "purple": [6,"78-81",83,85,92],
+            "purple-red-green": [84],
+            "purple-black": [82]
+        },
+        "rarity": {
+            "c": ["1-7","10-14",21,23,24,30,32,34,36,38,47,50,51,55,"62-67",69,"78-81",83,96,98,100,101],
+            "u": [8,9,15,22,27,31,33,35,37,40,45,46,48,49,52,61,68,70,71,73,"93-95",97,99,102],
+            "r": [16,17,19,25,26,39,41,42,53,54,56,58,72,74,76,82,"86-90"],
+            "sr": [18,20,28,29,44,59,60,75,77,84,91,92],
+            "ur": [43,57,85],
+            "sec": [103,104]
+        },
+        "info_url": "https://world.digimoncard.com/products/pack/ver25/"
+    },
+    // Booster Dual Revolution [BT-25] - Alternatives --- bt25_alts
+    {
+        "id": null,
+        "block": 6,
+        "slug": "bt25_alts",
+        "name": "Booster Dual Revolution [BT-25] - Alternatives",
+        "release": "May 22, 2026",
+        "url": "bandaitcgplusURL/BT25/e_setID-cardIDparallel.png",
+        "cards": {
+            "BT25-018": "P_D",
+            "BT25-020": "P_D",
+            "BT25-028": "P_D",
+            "BT25-029": "P_D",
+            "BT25-043": "P_D",
+            "BT25-044": "P_D",
+            "BT25-057": "P_D",
+            "BT25-059": "P_D",
+            "BT25-060": "P_D",
+            "BT25-075": "P_D",
+            "BT25-077": "P_D",
+            "BT25-084": "P_D",
+            "BT25-085": "P_D",
+            "BT25-086": "P_D",
+            "BT25-088": "P_D",
+            "BT25-090": "P_D",
+            "BT25-091": "P_D",
+            "BT25-092": "P_D",
+            "BT25-103": ["P_D","P2"],
+            "BT25-104": ["P_D","P2"],
+        },
+        "info_url": "https://world.digimoncard.com/products/pack/ver25/"
+    },
+    // Booster Dual Revolution [BT-25] - Special Cards --- bt25_special
+    {
+        "id": null,
+        "block": 6,
+        "slug": "bt25_special",
+        "name": "Booster Dual Revolution [BT-25] - Special Cards",
+        "release": "May 22, 2026",
+        "url": "bandaitcgplusURL/BT25/e_setID-cardIDSP_D.png",
+        "cards": {
+            "BT25-043": "",
+            "BT25-057": "",
+            "BT25-085": "",
+            "BT25-091": "",
+            "BT25-092": "",
+        },
+        "rarity": "sp",
+        "info_url": "https://world.digimoncard.com/products/pack/ver25/"
+    },
+    // Booster Dual Revolution [BT-25] - Box Promotion Pack --- bt25_boxtopper
+    {
+        "id": null,
+        "block": 6,
+        "slug": "bt25_boxtopper",
+        "name": "Booster Dual Revolution [BT-25] - Box Promotion Pack",
+        "release": "May 22, 2026",
+        "url": "bandaitcgplusURL/BT25/e_setID-cardIDP_D.png",
+        "cards": {
+            "BT25-009": "",
+            "BT25-031": "",
+            "BT25-035": "",
+            "BT25-045": "",
+            "BT25-046": "",
+            "BT25-061": "",
+        },
+        "info_url": "https://world.digimoncard.com/products/pack/ver25/"
+    },
+    // Booster Dual Revolution [BT-25] - Restricted Reprints --- bt25_restricted
     {
         "id": null,
         "block": {
-            "1": ["BT8","ST10"],
-            "2": ["BT5","BT11","BT13","EX3","ST14"],
-            "3": ["EX5","EX6"],
-            "4": ["LM","ST19"]
+            "0": ["BT2"],
+            "1": ["EX1","BT7"],
+            "2": ["BT3","BT11"],
+            "3": ["BT4"]
         },
-        "slug": "pb23",
-        "name": "Premium Heroines Set ver.2 [PB-23]",
-        "release": "January 2026",
-        "url": "bandaitcgplusURL/PB23/parallel_setID-cardID.png",
+        "slug": "bt25_restricted",
+        "name": "Booster Dual Revolution [BT-25] - Restricted Reprints",
+        "release": "May 22, 2026",
+        "url": "bandaitcgplusURL/BT25/e_setID-cardID_BT25_D.png",
         "cards": {
-            "BT5-092": "Same",
-            "BT8-082": "Same",
-            "BT11-089": "Same",
-            "BT11-112": "Same",
-            "BT13-057": "Same",
-            "EX3-065": "e",
-            "EX5-025": "Same",
-            "EX6-074": "Same",
-            "P-195": "Same",
-            "LM-042": "Same",
-            "ST10-06": "Same",
-            "ST14-09": "Same",
-            "ST19-12": "Same",
+            "BT2-047": "",
+            "BT3-103": "",
+            "BT4-104": "",
+            "BT7-107": "",
+            "BT11-064": "",
+            "EX1-068": "",
+
         },
-        "info_url": "https://world.digimoncard.com/products/goods/premium-heroines-set-02.php"
+        "info_url": "https://world.digimoncard.com/products/pack/ver25/"
+    },
+
+// June 1 - July 31, 2026
+    // Evolution Cup 2026 Vol.2 Participation --- evolution_cup_2026_2_participant
+    {
+        "id": null,
+        "block": 5,
+        "slug": "evolution_cup_2026_2_participant",
+        "name": "Evolution Cup 2026 Vol.2 Participation",
+        "release": "June 1 - July 31, 2026",
+        "url": "noCardURL",
+        "cards": {
+            "BT22-004": "",
+        },
+        "info_url": "https://world.digimoncard.com/event/2026/evolution-cup/02/",
+    },
+    // Evolution Cup 2026 Vol.2 Top 4 --- evolution_cup_2026_2_top4
+    {
+        "id": null,
+        "block": 5,
+        "slug": "evolution_cup_2026_2_top4",
+        "name": "Evolution Cup 2026 Vol.2 Top 4",
+        "release": "June 1 - July 31, 2026",
+        "url": "noCardURL",
+        "cards": {
+            "BT22-099": "",
+        },
+        "info_url": "https://world.digimoncard.com/event/2026/evolution-cup/02/",
+    },
+    // Evolution Cup 2026 Vol.2 Winner --- evolution_cup_2026_2_winner
+    {
+        "id": null,
+        "block": 5,
+        "slug": "evolution_cup_2026_2_winner",
+        "name": "Evolution Cup 2026 Vol.2 Winner",
+        "release": "June 1 - July 31, 2026",
+        "url": "noCardURL",
+        "cards": {
+            "BT22-063": "",
+        },
+        "info_url": "https://world.digimoncard.com/event/2026/evolution-cup/02/",
+    },
+
+// July 3, 2026
+    // Extra Booster Digital World Shambala [EX-12] --- ex12
+    {
+        "id": "EX12",
+        "block": 6,
+        "slug": "ex12",
+        "name": "Extra Booster Digital World Shambala [EX-12]",
+        "release": "July 3, 2026",
+        "total": 77,
+        "url": "noCardURL",
+        // "url": "bandaitcgplusURL/EX12/e_setID-cardID_D.png",
+        "add_zero": 3,
+        "playmat": "",
+        "color": {},
+        "rarity": {},
+        "info_url": "https://world.digimoncard.com/products/pack/ex-12/"
+    },
+    // Extra Booster Digital World Shambala [EX-12] - Alternatives --- ex12_alts
+    {
+        "id": null,
+        "block": 6,
+        "slug": "ex12_alts",
+        "name": "Extra Booster Digital World Shambala [EX-12] - Alternatives",
+        "release": "July 3, 2026",
+        "url": "noCardURL",
+        // "url": "bandaitcgplusURL/EX12/e_setID-cardIDparallel_D.png",
+        "cards": {
+        },
+        "info_url": "https://world.digimoncard.com/products/pack/ex-12/"
+    },
+    // Extra Booster Digital World Shambala [EX-12] - Limited Cards --- ex12_limited
+    {
+        "id": null,
+        "block": 6,
+        "slug": "ex12_limited",
+        "name": "Extra Booster Digital World Shambala [EX-12] - Limited Cards",
+        "release": "July 3, 2026",
+        "url": "noCardURL",
+        // "url": "bandaitcgplusURL/EX12/e_setID-cardIDLP_D.png",
+        "cards": {
+        },
+        "info_url": "https://world.digimoncard.com/products/pack/ex-12/"
+    },
+    // Extra Booster Digital World Shambala [EX-12] - Special Cards --- ex12_special
+    {
+        "id": null,
+        "block": 6,
+        "slug": "ex12_special",
+        "name": "Extra Booster Digital World Shambala [EX-12] - Special Cards",
+        "release": "July 3, 2026",
+        "url": "noCardURL",
+        // "url": "bandaitcgplusURL/EX12/e_setID-cardIDSP_D.png",
+        "cards": {
+        },
+        "rarity": "sp",
+        "info_url": "https://world.digimoncard.com/products/pack/ex-12/"
+    },
+    // Extra Booster Digital World Shambala [EX-12] - Box Promotion Pack --- ex12_boxtopper
+    {
+        "id": null,
+        "block": 6,
+        "slug": "ex12_boxtopper",
+        "name": "Extra Booster Digital World Shambala [EX-12] - Box Promotion Pack",
+        "release": "July 3, 2026",
+        "url": "noCardURL",
+        // "url": "bandaitcgplusURL/EX12/e_setID-cardIDparallel_D.png",
+        "cards": {
+        },
+        "info_url": "https://world.digimoncard.com/products/pack/ex-12/"
     },
 
 // August 2026
@@ -1111,5 +1769,80 @@ const data2026 = [
             "EX8-029": "",
         },
         "info_url": "https://world.digimoncard.com/products/goods/limited-lm-07.php"
+    },
+
+// November 2026
+    // Limited Card Pack DISTANCIA CERO [LM-09] --- lm09
+    {
+        "id": null,
+        "block": 6,
+        "slug": "lm09",
+        "name": "Limited Card Pack DISTANCIA CERO [LM-09]",
+        "release": "November 2026",
+        "url": "noCardURL",
+        "cards": {
+            "LM-063": "",
+            "LM-064": "",
+            "LM-065": "",
+            "LM-066": "",
+            "LM-067": "",
+            "LM-068": "",
+        },
+        "info_url": "https://world.digimoncard.com/products/goods/limited-lm-09.php"
+    },
+    // Limited Card Pack DISTANCIA CERO [LM-09] - Alternatives --- lm09_alts
+    {
+        "id": null,
+        "block": {
+            "3": ["EX5"],
+            "4": ["EX7"],
+            "5": ["BT22","BT23"]
+        },
+        "slug": "lm09_alts",
+        "name": "Limited Card Pack DISTANCIA CERO [LM-09] - Alternatives",
+        "release": "November 2026",
+        "url": "noCardURL",
+        "cards": {
+            "BT22-005": "",
+            "BT23-013": "",
+            "EX5-063": "",
+            "EX7-073": "",
+        },
+        "info_url": "https://world.digimoncard.com/products/goods/limited-lm-09.php"
+    },
+    // Limited Card Pack DISTANCIA CERO [LM-09] - Reprints --- lm09_reprints
+    {
+        "id": null,
+        "slug": "lm09_reprints",
+        "name": "Limited Card Pack DISTANCIA CERO [LM-09] - Reprints",
+        "release": "November 2026",
+        // TODO: revisar block
+        "url": "noCardURL",
+        "cards": {
+            "P-229": "",
+            "P-232": "",
+            "P-233": "",
+            "P-234": "",
+            "P-235": "",
+            "P-236": "",
+            "P-237": "",
+            "P-238": "",
+            "P-239": "",
+            "P-240": "",
+            "P-241": "",
+            "P-242": "",
+            "P-243": "",
+            "P-244": "",
+            "BT20-013": "",
+            "BT21-046": "",
+            "BT23-092": "",
+            "BT23-099": "",
+            "BT24-018": "",
+            "BT24-085": "",
+            "ST22-13": "",
+            "EX5-058": "",
+            "EX7-051": "",
+        },
+        "info_url": "https://world.digimoncard.com/products/goods/limited-lm-09.php"
     },
 ];

--- a/js/data/data_norelease.js
+++ b/js/data/data_norelease.js
@@ -5,7 +5,7 @@ const dataNoRelease = [
         "id": "P",
         "name": "Promos",
         "release": null,
-        "total": 232,
+        "total": 238,
         "url": null,
         "add_zero": 3,
         "info_url": null,

--- a/js/data/data_norelease.js
+++ b/js/data/data_norelease.js
@@ -47,6 +47,7 @@ const dataNoRelease = [
     // Booster New Evolution [BT1]
     {
         "id": "BT1",
+        "block": 0,
         "name": "Booster New Evolution [BT1]",
         "release": null,
         "total": 115,
@@ -71,6 +72,7 @@ const dataNoRelease = [
     // Booster Ultimate Power [BT2]
     {
         "id": "BT2",
+        "block": 0,
         "name": "Booster Ultimate Power [BT2]",
         "release": null,
         "total": 112,
@@ -97,6 +99,7 @@ const dataNoRelease = [
     // Booster Union Impact [BT3]
     {
         "id": "BT3",
+        "block": 0,
         "name": "Booster Union Impact [BT3]",
         "release": null,
         "total": 112,

--- a/js/filters.js
+++ b/js/filters.js
@@ -22,7 +22,8 @@ const filterCards = () => {
         "status": document.getElementById('status').value,
         "color": document.getElementById('color').value,
         "set": document.getElementById('setValue').value,
-        "rarity": document.getElementById('rarity').value
+        "rarity": document.getElementById('rarity').value,
+        "block": document.getElementById('block').value
     }
     const setLists = document.getElementById('setLists');
     const content = document.getElementById('content');
@@ -122,6 +123,24 @@ const filterCards = () => {
         queryCards += `[data-rarity="${filters.rarity}"]`;
         cardClasses.push('filtered--rarity');
         rowClasses.push('match_filter--rarity');
+    }
+
+    // Block filter
+    const cleanFilterBlock = () => {
+        const filterCards = document.querySelectorAll('.filtered--block');
+        filterCards.forEach(card => {
+            card.classList.remove('filtered--block');
+            card.parentElement.parentElement.classList.remove('match_filter--block');
+        });
+        setLists.className = setLists.className.replace(/\bblock--\d+\b/g, '').trim();
+        setLists.classList.remove('filter--block');
+    }
+    cleanFilterBlock();
+    if (filters.block !== '') {
+        setLists.classList.add('filter--block', `block--${filters.block}`);
+        queryCards += `[data-block="${filters.block}"]`;
+        cardClasses.push('filtered--block');
+        rowClasses.push('match_filter--block');
     }
    
     const hideAllSets = () => {

--- a/js/index.js
+++ b/js/index.js
@@ -43,6 +43,8 @@ document.addEventListener("DOMContentLoaded", function (event) {
 
     // 0. Actualizar datos erroneos o desactualizados.
     // updatesData();
+    // migrateReprints();
+    // migrateReprintSlugsToBlocks();
 
     // 1. crear objeto collection y cardmarket si no existe. Si existe, obtener de storage.
     collection = JSON.parse( window.localStorage.getItem("collection") || '{}' );
@@ -130,7 +132,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
     }
 
     const drawAlternatives = (setElement) => {
-        const {name, url, cards, slug, reprint, rarity, rarities} = setElement;
+        const {name, url, cards, slug, reprint, block, rarity, rarities} = setElement;
         const setRarity = getCardsRarity(rarity ?? 'aa');
         const setRarities = rarities ? getCardsRarities(rarities) : undefined;
 
@@ -202,8 +204,8 @@ document.addEventListener("DOMContentLoaded", function (event) {
                         cardRow.getElementsByClassName('card_list')[0].innerHTML += getImageTag(cardUrl, name, `${cardNumber}__${slug}`, slug, collection[setId][cardId].cards[slug].status, collection[setId][cardId].cards[slug].bought, cardRarity);
                     }
 
-                    if ( reprint ) {
-                        cardRow.cells[1].innerHTML += `<input class="amount-card amount-card--reprint" type="text" data-card-number="${cardNumber}" onblur="updateValue(this)" onfocus="selectValue()" readonly value="${collection[setId][cardId].reprint || 0}">`;
+                    if ( reprint && block !== undefined && !cardRow.querySelector(`.amount-card--reprint[data-block="${block}"]`) ) {
+                        cardRow.cells[1].innerHTML += `<input class="amount-card amount-card--reprint" type="text" data-card-number="${cardNumber}" data-block="${block}" onblur="updateValue(this)" onfocus="selectValue()" readonly value="${collection[setId][cardId].reprint?.[block] || 0}">`;
                     }
                 }
             });

--- a/js/index.js
+++ b/js/index.js
@@ -96,7 +96,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
 
     // TODO: pasar un objeto con todo los parámetros, en lugar de incrementar el número de parámetros.
     // O incluso crear una clase card que se encargue de gestionar todo esto.
-    const getImageTag = (url, title, id, set, status = 0, bought = 0, rarity = 'aa') => {
+    const getImageTag = (url, title, id, set, status = 0, bought = 0, rarity = 'aa', block = null) => {
         const [cardNumber, slug] = id.split('__');
         const [setId, cardId] = cardNumber.split('-');
         let cardmarketUrl = '';
@@ -108,7 +108,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
             cardmarketPrice = cardmarket[setId][cardId][slug].price?.slice(-1)[0] || '';
         }
 
-        const imageCard = `<img loading="lazy" class="card" src="${url}" title="${title}" alt="${title}" id="${id}" data-set="${set}" data-status="${status}" data-bought="${bought}" data-cardmarketurl="${cardmarketUrl}" data-cardmarketprice="${cardmarketPrice}" data-rarity="${rarity}" data-type="card" onclick="modalOpen(this)">`;
+        const imageCard = `<img loading="lazy" class="card" src="${url}" title="${title}" alt="${title}" id="${id}" data-set="${set}" data-status="${status}" data-bought="${bought}" data-cardmarketurl="${cardmarketUrl}" data-cardmarketprice="${cardmarketPrice}" data-rarity="${rarity}" data-block="${block}" data-type="card" onclick="modalOpen(this)">`;
 
         return imageCard;
     }
@@ -149,7 +149,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                     }
 
                     // TODO: añadir cardRarity
-                    cardRow.getElementsByClassName('card_list')[0].innerHTML += getImageTag(cardUrl, name, `${cardNumber}__${slug}`, slug, collection[setId][cardId].cards[slug].status, collection[setId][cardId].cards[slug].bought);
+                    cardRow.getElementsByClassName('card_list')[0].innerHTML += getImageTag(cardUrl, name, `${cardNumber}__${slug}`, slug, collection[setId][cardId].cards[slug].status, collection[setId][cardId].cards[slug].bought, undefined, getCardBlock(cardNumber, block));
                 }
             });
         } else {
@@ -186,7 +186,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                                 cardUrl = getImageUrl(setElement.override.url, setId, cardId, parallelElement);
                             }
 
-                            cardRow.getElementsByClassName('card_list')[0].innerHTML += getImageTag(cardUrl, name, `${cardNumber}__${slug}_${index}`, slug, collection[setId][cardId].cards[parallel_slug].status, collection[setId][cardId].cards[parallel_slug].bought, cardRarity);
+                            cardRow.getElementsByClassName('card_list')[0].innerHTML += getImageTag(cardUrl, name, `${cardNumber}__${slug}_${index}`, slug, collection[setId][cardId].cards[parallel_slug].status, collection[setId][cardId].cards[parallel_slug].bought, cardRarity, getCardBlock(cardNumber, block));
                         });
                     } else {
                         // 5. si no existe la carta, la añadimos al set
@@ -201,11 +201,17 @@ document.addEventListener("DOMContentLoaded", function (event) {
                             cardUrl = getImageUrl(setElement.override.url, setId, cardId, overrideParallel);
                         }
                         
-                        cardRow.getElementsByClassName('card_list')[0].innerHTML += getImageTag(cardUrl, name, `${cardNumber}__${slug}`, slug, collection[setId][cardId].cards[slug].status, collection[setId][cardId].cards[slug].bought, cardRarity);
+                        cardRow.getElementsByClassName('card_list')[0].innerHTML += getImageTag(cardUrl, name, `${cardNumber}__${slug}`, slug, collection[setId][cardId].cards[slug].status, collection[setId][cardId].cards[slug].bought, cardRarity, getCardBlock(cardNumber, block));
                     }
 
-                    if ( reprint && block !== undefined && !cardRow.querySelector(`.amount-card--reprint[data-block="${block}"]`) ) {
-                        cardRow.cells[1].innerHTML += `<input class="amount-card amount-card--reprint" type="text" data-card-number="${cardNumber}" data-block="${block}" onblur="updateValue(this)" onfocus="selectValue()" readonly value="${collection[setId][cardId].reprint?.[block] || 0}">`;
+                    const cardBlock = getCardBlock(cardNumber, block);
+                    if ( cardBlock !== null ) {
+                        const mainInput = cardRow.querySelector('.amount-card:not([data-block])');
+                        if ( mainInput ) {
+                            mainInput.dataset.block = cardBlock;
+                        } else if ( !cardRow.querySelector(`.amount-card[data-block="${cardBlock}"]`) ) {
+                            cardRow.cells[1].innerHTML += `<input class="amount-card amount-card--reprint" type="text" data-card-number="${cardNumber}" data-block="${cardBlock}" onblur="updateValue(this)" onfocus="selectValue()" readonly value="${collection[setId][cardId].reprint?.[cardBlock] || 0}">`;
+                        }
                     }
                 }
             });
@@ -288,6 +294,16 @@ document.addEventListener("DOMContentLoaded", function (event) {
         return cardsRarities;
     }
 
+    const getCardBlock = (cardId, block) => {
+        if (typeof block === 'number') return block;
+        if (!block) return null;
+        const setPrefix = cardId.replace(/-\d+$/, '');
+        for (const [b, entries] of Object.entries(block)) {
+            if (entries.includes(cardId) || entries.includes(setPrefix)) return Number(b);
+        }
+        return null;
+    }
+
     sets.forEach(setElement => {
         if (setElement.id !== null) {
             const tableSet = document.createElement('table');
@@ -327,7 +343,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                     collection[setElement.id][cardId] = {amount: 0, cards: {}};
                 }
                 
-                row.insertCell(1).innerHTML = `<input class="amount-card" type="text" data-card-number="${cardNumber}" onblur="updateValue(this)" onfocus="selectValue()" readonly value="${collection[setElement.id][cardId].amount}">`;
+                row.insertCell(1).innerHTML = `<input class="amount-card" type="text" data-card-number="${cardNumber}"${setElement.block !== undefined ? ` data-block="${setElement.block}"` : ''} onblur="updateValue(this)" onfocus="selectValue()" readonly value="${collection[setElement.id][cardId].amount}">`;
                 row.dataset.pull = collection[setElement.id][cardId].amount >= 4;
                 row.dataset.rarity = cardRarity;
 
@@ -345,7 +361,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                     }
 
                     // TODO: añadir cardRarity
-                    row.insertCell(2).innerHTML = getImageTag(cardUrl, setElement.name, `${cardNumber}__${setElement.slug}`, setElement.slug, collection[setElement.id][cardId].cards[setElement.slug].status, collection[setElement.id][cardId].cards[setElement.slug].bought, cardRarity);
+                    row.insertCell(2).innerHTML = getImageTag(cardUrl, setElement.name, `${cardNumber}__${setElement.slug}`, setElement.slug, collection[setElement.id][cardId].cards[setElement.slug].status, collection[setElement.id][cardId].cards[setElement.slug].bought, cardRarity, setElement.block);
                 } else {
                     row.insertCell(2).innerHTML = "";
                 }

--- a/js/modal.js
+++ b/js/modal.js
@@ -196,10 +196,14 @@ const updateValue = (element) => {
     element.setAttribute('value', element.value);
     const [set, id] = element.dataset.cardNumber.split('-');
     if ( element.classList.contains('amount-card--reprint') ) {
+        const block = element.dataset.block;
         if ( element.value > 0 ) {
-            collection[set][id].reprint = parseInt(element.value);
-        } else {
-            delete collection[set][id].reprint;
+            (collection[set][id].reprint ??= {})[block] = parseInt(element.value);
+        } else if ( collection[set][id].reprint ) {
+            delete collection[set][id].reprint[block];
+            if ( Object.keys(collection[set][id].reprint).length === 0 ) {
+                delete collection[set][id].reprint;
+            }
         }
     } else {
         element.parentElement.parentElement.dataset.pull = element.value >= 4;

--- a/js/updates.js
+++ b/js/updates.js
@@ -1,3 +1,73 @@
+const migrateReprints = () => {
+    const collectionJson = JSON.parse(localStorage.getItem('collection') || '{}');
+    const reprintBlocks = {};
+
+    sets.forEach(s => {
+        if (s.id === null && s.reprint && s.block !== undefined && s.cards) {
+            Object.keys(s.cards).forEach(cardNumber => {
+                const [setId, cardId] = cardNumber.split('-');
+                (reprintBlocks[setId] ??= {})[cardId] ??= s.block;
+            });
+        }
+    });
+
+    let migrated = false;
+    for (const setId in collectionJson) {
+        if (typeof collectionJson[setId] !== 'object' || setId === 'products') continue;
+        for (const cardId in collectionJson[setId]) {
+            const card = collectionJson[setId][cardId];
+            if (typeof card.reprint === 'number') {
+                const block = reprintBlocks[setId]?.[cardId];
+                if (block !== undefined && card.reprint > 0) {
+                    card.reprint = { [block]: card.reprint };
+                } else {
+                    delete card.reprint;
+                }
+                migrated = true;
+            }
+        }
+    }
+
+    if (migrated) {
+        localStorage.setItem('collection', JSON.stringify(collectionJson));
+    }
+};
+
+const migrateReprintSlugsToBlocks = () => {
+    const collectionJson = JSON.parse(localStorage.getItem('collection') || '{}');
+    const slugToBlock = {};
+
+    sets.forEach(s => {
+        if (s.id === null && s.reprint && s.block !== undefined) {
+            slugToBlock[s.slug] ??= s.block;
+        }
+    });
+
+    let migrated = false;
+    for (const setId in collectionJson) {
+        if (typeof collectionJson[setId] !== 'object' || setId === 'products') continue;
+        for (const cardId in collectionJson[setId]) {
+            const card = collectionJson[setId][cardId];
+            if (typeof card.reprint !== 'object') continue;
+            for (const key in card.reprint) {
+                if (key in slugToBlock) {
+                    const block = slugToBlock[key];
+                    card.reprint[block] = (card.reprint[block] || 0) + card.reprint[key];
+                    delete card.reprint[key];
+                    migrated = true;
+                }
+            }
+            if (Object.keys(card.reprint).length === 0) {
+                delete card.reprint;
+            }
+        }
+    }
+
+    if (migrated) {
+        localStorage.setItem('collection', JSON.stringify(collectionJson));
+    }
+};
+
 const updatesData = ( version ) => {
     // TODO: Mejora de ejecución de script.
     // 1. detectar la versión de los datos.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dtcg-web-collection",
-	"version": "1.1.1",
+	"version": "1.4.0",
 	"description": "Little project to manage your own Digimon TCG",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1",

--- a/sass/_card.scss
+++ b/sass/_card.scss
@@ -32,6 +32,7 @@ $rarity-backgrounds: (
   "green-yellow": white-black,
   "green-black": white,
   "green-purple": white,
+  "green-white": white-black,
   "black": white,
   "black-red": white,
   "black-yellow": white-black,
@@ -40,6 +41,7 @@ $rarity-backgrounds: (
   "black-white": white-black,
   "purple": white,
   "purple-red": white,
+  "purple-red-green": white,
   "purple-yellow": white-black,
   "purple-green": white,
   "purple-black": white,
@@ -229,6 +231,7 @@ $rarity-backgrounds: (
   @include card-color("green", "black", "black", "white", "yellow");
   @include card-color("green", "purple");
   @include card-color("green", "purple", "black", "white", "yellow");
+  @include card-color("green", "white", "black");
 
   // Black cards
   @include card-color("black");
@@ -244,6 +247,7 @@ $rarity-backgrounds: (
   // Purple cards
   @include card-color("purple");
   @include card-color("purple", "red");
+  @include card-color("purple", "green", "", "", "red");
   @include card-color("purple", "blue");
   @include card-color("purple", "yellow", "black");
   @include card-color("purple", "green");

--- a/sass/_filters.scss
+++ b/sass/_filters.scss
@@ -26,6 +26,24 @@
     }
 }
 
+.filter--block {
+    tbody tr:not(.match_filter--block) {
+        display: none;
+    }
+
+    .card:not(.filtered--block) {
+        display: none;
+    }
+
+    @for $i from 0 through 6 {
+        &.block--#{$i} {
+            .amount-card:not([data-block="#{$i}"]) {
+                display: none;
+            }
+        }
+    }
+}
+
 .filter--color {
     tbody tr:not(.filtered--color) {
         display: none;


### PR DESCRIPTION
Merge de `develop` a `main` con los siguientes cambios acumulados:

- feat: asignación de bloques a todos los sets (PR #31) → v1.2.0
- data: nuevos sets 2026 (PR #32) → v1.3.0
- feat: block UI — getCardBlock, inputs por bloque, filtro por bloque (PR #38) → v1.4.0
- chore: CHANGELOG y versión 1.4.0 (PR #39)