### PR TITLE
feat: block UI (#34, #35, #36)

### DIFF
--- a/DATA_MODEL.md
+++ b/DATA_MODEL.md
@@ -434,6 +434,8 @@ Estructura del objeto `collection` almacenado en localStorage:
 | `[setId][cardId].reprint` | `object` | Opcional. Cantidad de copias por bloque de reprint: `{ "5": 2 }` |
 | `products.packs[slug]` | `object` | Estado y precio de cada sobre/producto |
 
+> **Pendiente (#37):** `amount` pasará a ser un mapa por bloque `{ "0": 2, "1": 3 }` y se eliminará el campo `reprint`. La suma total se calculará en runtime. Ver issue [#37](https://github.com/Vegekku/dtcg-web/issues/37).
+
 ---
 
 ## localStorage: cardmarket

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -6,7 +6,7 @@
 |-----------|-------|
 | 🔴 Alta | [1](#item-1), [5](#item-5), [7](#item-7), [19](#item-19), [33](#item-33), [38](#item-38), [64](#item-64) |
 | 🟠 Media | [2](#item-2), [3](#item-3), [4](#item-4), [8](#item-8), [10](#item-10), [12](#item-12), [16](#item-16), [17](#item-17), [18](#item-18), [20](#item-20), [27](#item-27), [29](#item-29), [39](#item-39), [40](#item-40), [68](#item-68), [73](#item-73) |
-| 🟡 Baja | [6](#item-6), [9](#item-9), [11](#item-11), [13](#item-13), [14](#item-14), [15](#item-15), [21](#item-21)–[26](#item-26), [28](#item-28), [30](#item-30)–[32](#item-32), [34](#item-34)–[37](#item-37), [41](#item-41)–[67](#item-67), [69](#item-69)–[72](#item-72), [74](#item-74) |
+| 🟡 Baja | [6](#item-6), [9](#item-9), [11](#item-11), [13](#item-13), [14](#item-14), [15](#item-15), [21](#item-21)–[26](#item-26), [28](#item-28), [30](#item-30)–[32](#item-32), [34](#item-34)–[37](#item-37), [41](#item-41)–[67](#item-67), [69](#item-69)–[72](#item-72), [74](#item-74), [75](#item-75) |
 
 ---
 
@@ -707,4 +707,20 @@ No separar en dos pasadas (IDs exactos vs prefijos): el coste es insignificante 
 Cuando un set mezcla cartas de distintos bloques y se quiere usar un prefijo general para el bloque mayoritario, colocar el prefijo en el bloque más alto y los IDs específicos en los bloques inferiores. Así los IDs exactos se encuentran antes en la iteración y el prefijo actúa como fallback. El orden inverso (prefijo en bloque bajo) requeriría dos pasadas.
 
 > **Contexto:** Reprint = cualquier reimpresión posterior a la original (incluye alternativas y cambios de bloque). Se mantiene tracking por bloque para posible rotación futura. En la UI, el modo visualización muestra la suma total con desglose por bloque; el modo edición muestra inputs individuales por bloque.
+
+<a id="item-75"></a>
+
+### 75. `amount` como mapa por bloque <sup>[↑](#prioridad-sugerida)</sup>
+
+Cambiar la estructura de `collection[setId][cardId].amount` de número a mapa por bloque, eliminando el campo `reprint`. Ver issue [#37](https://github.com/Vegekku/dtcg-web/issues/37).
+
+```js
+// Antes
+{ amount: 4, reprint: { "0": 2, "1": 3 }, cards: { ... } }
+
+// Después
+{ amount: { "0": 4, "1": 2, "2": 3 }, cards: { ... } }
+```
+
+La suma total se calcula en runtime: `Object.values(amount).reduce((a, b) => a + b, 0)`. Cambio MAJOR — requiere migración de datos en localStorage.
 

--- a/css/style.css
+++ b/css/style.css
@@ -940,6 +940,27 @@ button.accordion.active:after {
 .filter--block .card:not(.filtered--block) {
   display: none;
 }
+.filter--block.block--0 .amount-card:not([data-block="0"]) {
+  display: none;
+}
+.filter--block.block--1 .amount-card:not([data-block="1"]) {
+  display: none;
+}
+.filter--block.block--2 .amount-card:not([data-block="2"]) {
+  display: none;
+}
+.filter--block.block--3 .amount-card:not([data-block="3"]) {
+  display: none;
+}
+.filter--block.block--4 .amount-card:not([data-block="4"]) {
+  display: none;
+}
+.filter--block.block--5 .amount-card:not([data-block="5"]) {
+  display: none;
+}
+.filter--block.block--6 .amount-card:not([data-block="6"]) {
+  display: none;
+}
 
 .filter--color tbody tr:not(.filtered--color) {
   display: none;

--- a/css/style.css
+++ b/css/style.css
@@ -934,6 +934,13 @@ button.accordion.active:after {
   display: none;
 }
 
+.filter--block tbody tr:not(.match_filter--block) {
+  display: none;
+}
+.filter--block .card:not(.filtered--block) {
+  display: none;
+}
+
 .filter--color tbody tr:not(.filtered--color) {
   display: none;
 }

--- a/index.html
+++ b/index.html
@@ -89,6 +89,18 @@
                 <option value="c">Common</option>
                 <option value="t">Token</option>
             </select>
+
+            <label for="block">Bloque</label>
+            <select name="block" id="block" onchange="filterCards()">
+                <option value="">Todos</option>
+                <option value="0">Bloque 0</option>
+                <option value="1">Bloque 1</option>
+                <option value="2">Bloque 2</option>
+                <option value="3">Bloque 3</option>
+                <option value="4">Bloque 4</option>
+                <option value="5">Bloque 5</option>
+                <option value="6">Bloque 6</option>
+            </select>
         </div>
         <div class="views">
             <label for="list">Listar como</label>

--- a/js/data/data_2021.js
+++ b/js/data/data_2021.js
@@ -1092,7 +1092,7 @@ const data2021 = [
     // June Premier TO events --- premierto
     {
         "id": null,
-        "block": 1,
+        "block": 0, // las cartas tiene bloque 1, pero al ser premios lo consideramos por su bloque original 0
         "slug": "premierto",
         "name": "June Premier TO events",
         "release": "June 2021",

--- a/js/data/data_2022.js
+++ b/js/data/data_2022.js
@@ -162,7 +162,7 @@ const data2022 = [
     // 2021 Final Championships Framed Trophy Cards - 1st Place Champion --- fcftc_2021_1st
     {
         "id": null,
-        "block": 0, // Posible error de impresión y le corresponda bloque 1
+        "block": 1, // La carta tiene bloque 0, pero es un premio asique lo consideramos por su bloque original 1
         "slug": "fcftc_2021_1st",
         "name": "2021 Final Championships Framed Trophy Cards - 1st Place Champion",
         "release": "January 2022",

--- a/js/data/data_2023.js
+++ b/js/data/data_2023.js
@@ -676,8 +676,8 @@ const data2023 = [
     {
         "id": null,
         "block": {
-            "0": ["BT6","BT7","BT8"],
-            "1": ["BT10","ST12","ST13"]
+            "1": ["BT6","BT7","BT8"],
+            "2": ["BT10","ST12","ST13"]
         },
         "slug": "judgepack3",
         "name": "Judge Pack 3",
@@ -838,8 +838,8 @@ const data2023 = [
     {
         "id": null,
         "block": {
-            "1": ["BT8","EX2","BT12-001"],
-            "2": ["BT12-007","BT12-010","BT12-016","BT12-018"]
+            "1": ["BT8","EX2"],
+            "2": ["BT12"] // BT12-001 tiene bloque 1, pero es un premio asique lo consideramos por su bloque original 2.
         },
         "slug": "ultimatecup_2023",
         "name": "Ultimate Cup 2023",
@@ -972,7 +972,7 @@ const data2023 = [
         "id": null,
         "block": {
             "1": ["BT6","ST9","ST10"],
-            "1": ["BT10","BT11","ST13"]
+            "2": ["BT10","BT11","ST13"]
         },
         "slug": "storechampion_2023_0",
         "name": "Store Championship 2023 Participant Pack",
@@ -995,7 +995,7 @@ const data2023 = [
         "id": null,
         "block": {
             "1": ["BT6","ST9","ST10"],
-            "1": ["BT10","BT11","ST13"]
+            "2": ["BT10","BT11","ST13"]
         },
         "slug": "storechampion_2023_1",
         "name": "Store Championship 2023 Top 4 Pack",

--- a/js/data/data_2024.js
+++ b/js/data/data_2024.js
@@ -2051,7 +2051,7 @@ const data2024 = [
         "id": null,
         "block": {
             "2": ["BT10","P"],
-            "4": ["BT16","EX6","ST17"]
+            "3": ["BT16","EX6","ST17"]
         },
         "slug": "regional2024_3_0",
         "name": "2024 Regionals Participant Card Set Wave 3",
@@ -2073,7 +2073,7 @@ const data2024 = [
         "id": null,
         "block": {
             "2": ["BT10","P"],
-            "4": ["BT16","EX6","ST17"]
+            "3": ["BT16","EX6","ST17"]
         },
         "slug": "regional2024_3_1",
         "name": "2024 Regionals Finalist Card Set Wave 3",
@@ -2095,7 +2095,7 @@ const data2024 = [
         "id": null,
         "block": {
             "2": ["BT10","P"],
-            "4": ["BT16","EX6","ST17"]
+            "3": ["BT16","EX6","ST17"]
         },
         "slug": "regional2024_3_2",
         "name": "2024 Regionals Champion Card Set Wave 3",

--- a/js/filters.js
+++ b/js/filters.js
@@ -22,7 +22,8 @@ const filterCards = () => {
         "status": document.getElementById('status').value,
         "color": document.getElementById('color').value,
         "set": document.getElementById('setValue').value,
-        "rarity": document.getElementById('rarity').value
+        "rarity": document.getElementById('rarity').value,
+        "block": document.getElementById('block').value
     }
     const setLists = document.getElementById('setLists');
     const content = document.getElementById('content');
@@ -122,6 +123,23 @@ const filterCards = () => {
         queryCards += `[data-rarity="${filters.rarity}"]`;
         cardClasses.push('filtered--rarity');
         rowClasses.push('match_filter--rarity');
+    }
+
+    // Block filter
+    const cleanFilterBlock = () => {
+        const filterCards = document.querySelectorAll('.filtered--block');
+        filterCards.forEach(card => {
+            card.classList.remove('filtered--block');
+            card.parentElement.parentElement.classList.remove('match_filter--block');
+        });
+        setLists.classList.remove('filter--block');
+    }
+    cleanFilterBlock();
+    if (filters.block !== '') {
+        setLists.classList.add('filter--block');
+        queryCards += `[data-block="${filters.block}"]`;
+        cardClasses.push('filtered--block');
+        rowClasses.push('match_filter--block');
     }
    
     const hideAllSets = () => {

--- a/js/filters.js
+++ b/js/filters.js
@@ -132,11 +132,12 @@ const filterCards = () => {
             card.classList.remove('filtered--block');
             card.parentElement.parentElement.classList.remove('match_filter--block');
         });
+        setLists.className = setLists.className.replace(/\bblock--\d+\b/g, '').trim();
         setLists.classList.remove('filter--block');
     }
     cleanFilterBlock();
     if (filters.block !== '') {
-        setLists.classList.add('filter--block');
+        setLists.classList.add('filter--block', `block--${filters.block}`);
         queryCards += `[data-block="${filters.block}"]`;
         cardClasses.push('filtered--block');
         rowClasses.push('match_filter--block');

--- a/js/index.js
+++ b/js/index.js
@@ -204,8 +204,14 @@ document.addEventListener("DOMContentLoaded", function (event) {
                         cardRow.getElementsByClassName('card_list')[0].innerHTML += getImageTag(cardUrl, name, `${cardNumber}__${slug}`, slug, collection[setId][cardId].cards[slug].status, collection[setId][cardId].cards[slug].bought, cardRarity, getCardBlock(cardNumber, block));
                     }
 
-                    if ( reprint && block !== undefined && !cardRow.querySelector(`.amount-card--reprint[data-block="${block}"]`) ) {
-                        cardRow.cells[1].innerHTML += `<input class="amount-card amount-card--reprint" type="text" data-card-number="${cardNumber}" data-block="${block}" onblur="updateValue(this)" onfocus="selectValue()" readonly value="${collection[setId][cardId].reprint?.[block] || 0}">`;
+                    const cardBlock = getCardBlock(cardNumber, block);
+                    if ( cardBlock !== null ) {
+                        const mainInput = cardRow.querySelector('.amount-card:not([data-block])');
+                        if ( mainInput ) {
+                            mainInput.dataset.block = cardBlock;
+                        } else if ( !cardRow.querySelector(`.amount-card[data-block="${cardBlock}"]`) ) {
+                            cardRow.cells[1].innerHTML += `<input class="amount-card amount-card--reprint" type="text" data-card-number="${cardNumber}" data-block="${cardBlock}" onblur="updateValue(this)" onfocus="selectValue()" readonly value="${collection[setId][cardId].reprint?.[cardBlock] || 0}">`;
+                        }
                     }
                 }
             });
@@ -337,7 +343,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                     collection[setElement.id][cardId] = {amount: 0, cards: {}};
                 }
                 
-                row.insertCell(1).innerHTML = `<input class="amount-card" type="text" data-card-number="${cardNumber}" onblur="updateValue(this)" onfocus="selectValue()" readonly value="${collection[setElement.id][cardId].amount}">`;
+                row.insertCell(1).innerHTML = `<input class="amount-card" type="text" data-card-number="${cardNumber}"${setElement.block !== undefined ? ` data-block="${setElement.block}"` : ''} onblur="updateValue(this)" onfocus="selectValue()" readonly value="${collection[setElement.id][cardId].amount}">`;
                 row.dataset.pull = collection[setElement.id][cardId].amount >= 4;
                 row.dataset.rarity = cardRarity;
 

--- a/js/index.js
+++ b/js/index.js
@@ -96,7 +96,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
 
     // TODO: pasar un objeto con todo los parámetros, en lugar de incrementar el número de parámetros.
     // O incluso crear una clase card que se encargue de gestionar todo esto.
-    const getImageTag = (url, title, id, set, status = 0, bought = 0, rarity = 'aa') => {
+    const getImageTag = (url, title, id, set, status = 0, bought = 0, rarity = 'aa', block = null) => {
         const [cardNumber, slug] = id.split('__');
         const [setId, cardId] = cardNumber.split('-');
         let cardmarketUrl = '';
@@ -108,7 +108,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
             cardmarketPrice = cardmarket[setId][cardId][slug].price?.slice(-1)[0] || '';
         }
 
-        const imageCard = `<img loading="lazy" class="card" src="${url}" title="${title}" alt="${title}" id="${id}" data-set="${set}" data-status="${status}" data-bought="${bought}" data-cardmarketurl="${cardmarketUrl}" data-cardmarketprice="${cardmarketPrice}" data-rarity="${rarity}" data-type="card" onclick="modalOpen(this)">`;
+        const imageCard = `<img loading="lazy" class="card" src="${url}" title="${title}" alt="${title}" id="${id}" data-set="${set}" data-status="${status}" data-bought="${bought}" data-cardmarketurl="${cardmarketUrl}" data-cardmarketprice="${cardmarketPrice}" data-rarity="${rarity}" data-block="${block}" data-type="card" onclick="modalOpen(this)">`;
 
         return imageCard;
     }
@@ -149,7 +149,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                     }
 
                     // TODO: añadir cardRarity
-                    cardRow.getElementsByClassName('card_list')[0].innerHTML += getImageTag(cardUrl, name, `${cardNumber}__${slug}`, slug, collection[setId][cardId].cards[slug].status, collection[setId][cardId].cards[slug].bought);
+                    cardRow.getElementsByClassName('card_list')[0].innerHTML += getImageTag(cardUrl, name, `${cardNumber}__${slug}`, slug, collection[setId][cardId].cards[slug].status, collection[setId][cardId].cards[slug].bought, undefined, getCardBlock(cardNumber, block));
                 }
             });
         } else {
@@ -186,7 +186,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                                 cardUrl = getImageUrl(setElement.override.url, setId, cardId, parallelElement);
                             }
 
-                            cardRow.getElementsByClassName('card_list')[0].innerHTML += getImageTag(cardUrl, name, `${cardNumber}__${slug}_${index}`, slug, collection[setId][cardId].cards[parallel_slug].status, collection[setId][cardId].cards[parallel_slug].bought, cardRarity);
+                            cardRow.getElementsByClassName('card_list')[0].innerHTML += getImageTag(cardUrl, name, `${cardNumber}__${slug}_${index}`, slug, collection[setId][cardId].cards[parallel_slug].status, collection[setId][cardId].cards[parallel_slug].bought, cardRarity, getCardBlock(cardNumber, block));
                         });
                     } else {
                         // 5. si no existe la carta, la añadimos al set
@@ -201,7 +201,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                             cardUrl = getImageUrl(setElement.override.url, setId, cardId, overrideParallel);
                         }
                         
-                        cardRow.getElementsByClassName('card_list')[0].innerHTML += getImageTag(cardUrl, name, `${cardNumber}__${slug}`, slug, collection[setId][cardId].cards[slug].status, collection[setId][cardId].cards[slug].bought, cardRarity);
+                        cardRow.getElementsByClassName('card_list')[0].innerHTML += getImageTag(cardUrl, name, `${cardNumber}__${slug}`, slug, collection[setId][cardId].cards[slug].status, collection[setId][cardId].cards[slug].bought, cardRarity, getCardBlock(cardNumber, block));
                     }
 
                     if ( reprint && block !== undefined && !cardRow.querySelector(`.amount-card--reprint[data-block="${block}"]`) ) {
@@ -288,6 +288,16 @@ document.addEventListener("DOMContentLoaded", function (event) {
         return cardsRarities;
     }
 
+    const getCardBlock = (cardId, block) => {
+        if (typeof block === 'number') return block;
+        if (!block) return null;
+        const setPrefix = cardId.replace(/-\d+$/, '');
+        for (const [b, entries] of Object.entries(block)) {
+            if (entries.includes(cardId) || entries.includes(setPrefix)) return Number(b);
+        }
+        return null;
+    }
+
     sets.forEach(setElement => {
         if (setElement.id !== null) {
             const tableSet = document.createElement('table');
@@ -345,7 +355,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                     }
 
                     // TODO: añadir cardRarity
-                    row.insertCell(2).innerHTML = getImageTag(cardUrl, setElement.name, `${cardNumber}__${setElement.slug}`, setElement.slug, collection[setElement.id][cardId].cards[setElement.slug].status, collection[setElement.id][cardId].cards[setElement.slug].bought, cardRarity);
+                    row.insertCell(2).innerHTML = getImageTag(cardUrl, setElement.name, `${cardNumber}__${setElement.slug}`, setElement.slug, collection[setElement.id][cardId].cards[setElement.slug].status, collection[setElement.id][cardId].cards[setElement.slug].bought, cardRarity, setElement.block);
                 } else {
                     row.insertCell(2).innerHTML = "";
                 }

--- a/sass/_filters.scss
+++ b/sass/_filters.scss
@@ -26,6 +26,16 @@
     }
 }
 
+.filter--block {
+    tbody tr:not(.match_filter--block) {
+        display: none;
+    }
+
+    .card:not(.filtered--block) {
+        display: none;
+    }
+}
+
 .filter--color {
     tbody tr:not(.filtered--color) {
         display: none;

--- a/sass/_filters.scss
+++ b/sass/_filters.scss
@@ -34,6 +34,14 @@
     .card:not(.filtered--block) {
         display: none;
     }
+
+    @for $i from 0 through 6 {
+        &.block--#{$i} {
+            .amount-card:not([data-block="#{$i}"]) {
+                display: none;
+            }
+        }
+    }
 }
 
 .filter--color {


### PR DESCRIPTION
Implementación completa de la UI de bloques.

## Cambios

- **#34** — Implementa `getCardBlock(cardId, block)` y asigna `data-block` a todas las imágenes de carta (sets base y `drawAlternatives`)
- **#35** — Pinta inputs de cantidad por bloque en `drawAlternatives`. Fix inputs duplicados en Promos (sets sin `block` en el set base)
- **#36** — Añade filtro por bloque en la barra de filtros. Al filtrar, oculta también los inputs de cantidad que no correspondan al bloque seleccionado

Closes #34
Closes #35
Closes #36