### PR TITLE
feat: amount como mapa por bloque (#37)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -829,10 +829,10 @@ tr:not([data-color]) .card_info__rarity, tr[data-color=undefined] .card_info__ra
   justify-content: center;
   background: white;
   color: black;
-  font-size: 0.6em;
+  font-size: 0.65em;
   font-weight: 700;
-  width: 18px;
-  height: 12px;
+  width: 10px;
+  height: 10px;
   clip-path: polygon(15% 0%, 85% 0%, 100% 50%, 85% 100%, 15% 100%, 0% 50%);
   pointer-events: none;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -794,6 +794,11 @@ tr:not([data-color]) .card_info__rarity, tr[data-color=undefined] .card_info__ra
   padding: 0;
 }
 
+.amount-card-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
 .amount-card[value=""] {
   background-color: transparent;
 }
@@ -812,6 +817,24 @@ tr:not([data-color]) .card_info__rarity, tr[data-color=undefined] .card_info__ra
 
 .amount-card[value="3"] {
   background-color: var(--three-cards);
+}
+
+.block-badge {
+  position: absolute;
+  bottom: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: white;
+  color: black;
+  font-size: 0.6em;
+  font-weight: 700;
+  width: 18px;
+  height: 12px;
+  clip-path: polygon(15% 0%, 85% 0%, 100% 50%, 85% 100%, 15% 100%, 0% 50%);
+  pointer-events: none;
 }
 
 button {

--- a/css/style.css
+++ b/css/style.css
@@ -831,7 +831,7 @@ tr:not([data-color]) .card_info__rarity, tr[data-color=undefined] .card_info__ra
   color: black;
   font-size: 0.65em;
   font-weight: 700;
-  width: 10px;
+  width: 20px;
   height: 10px;
   clip-path: polygon(15% 0%, 85% 0%, 100% 50%, 85% 100%, 15% 100%, 0% 50%);
   pointer-events: none;

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script src="js/utils.js"></script>
     <script src="js/data/data_norelease.js"></script>
     <script src="js/data/data_2021.js"></script>
     <script src="js/data/data_2022.js"></script>

--- a/js/index.js
+++ b/js/index.js
@@ -52,6 +52,8 @@ document.addEventListener("DOMContentLoaded", function (event) {
     cardmarket = JSON.parse( window.localStorage.getItem("cardmarket") || '{}' );
     (cardmarket.products ??= {}).packs ??= {};
 
+    migrateAmountToBlocks();
+
     /**
      * Gets the full URL to image card source.
      * @param {string} url The card url.
@@ -209,8 +211,10 @@ document.addEventListener("DOMContentLoaded", function (event) {
                         const mainInput = cardRow.querySelector('.amount-card:not([data-block])');
                         if ( mainInput ) {
                             mainInput.dataset.block = cardBlock;
+                            mainInput.value = collection[setId][cardId].amount?.[cardBlock] ?? 0;
+                            mainInput.setAttribute('value', mainInput.value);
                         } else if ( !cardRow.querySelector(`.amount-card[data-block="${cardBlock}"]`) ) {
-                            cardRow.cells[1].innerHTML += `<input class="amount-card amount-card--reprint" type="text" data-card-number="${cardNumber}" data-block="${cardBlock}" onblur="updateValue(this)" onfocus="selectValue()" readonly value="${collection[setId][cardId].reprint?.[cardBlock] || 0}">`;
+                            cardRow.cells[1].innerHTML += `<input class="amount-card amount-card--reprint" type="text" data-card-number="${cardNumber}" data-block="${cardBlock}" onblur="updateValue(this)" onfocus="selectValue()" readonly value="${collection[setId][cardId].amount?.[cardBlock] || 0}">`;
                         }
                     }
                 }
@@ -294,16 +298,6 @@ document.addEventListener("DOMContentLoaded", function (event) {
         return cardsRarities;
     }
 
-    const getCardBlock = (cardId, block) => {
-        if (typeof block === 'number') return block;
-        if (!block) return null;
-        const setPrefix = cardId.replace(/-\d+$/, '');
-        for (const [b, entries] of Object.entries(block)) {
-            if (entries.includes(cardId) || entries.includes(setPrefix)) return Number(b);
-        }
-        return null;
-    }
-
     sets.forEach(setElement => {
         if (setElement.id !== null) {
             const tableSet = document.createElement('table');
@@ -340,11 +334,14 @@ document.addEventListener("DOMContentLoaded", function (event) {
 
                 // 3. obtener cantidad de cartas de este id
                 if (collection[setElement.id][cardId] === undefined) {
-                    collection[setElement.id][cardId] = {amount: 0, cards: {}};
+                    collection[setElement.id][cardId] = {amount: {}, cards: {}};
                 }
-                
-                row.insertCell(1).innerHTML = `<input class="amount-card" type="text" data-card-number="${cardNumber}"${setElement.block !== undefined ? ` data-block="${setElement.block}"` : ''} onblur="updateValue(this)" onfocus="selectValue()" readonly value="${collection[setElement.id][cardId].amount}">`;
-                row.dataset.pull = collection[setElement.id][cardId].amount >= 4;
+
+                const blockKey = setElement.block !== undefined ? String(setElement.block) : null;
+                const blockAmount = blockKey !== null ? (collection[setElement.id][cardId].amount[blockKey] ?? 0) : 0;
+                const totalAmount = Object.values(collection[setElement.id][cardId].amount).reduce((a, b) => a + b, 0);
+                row.insertCell(1).innerHTML = `<input class="amount-card" type="text" data-card-number="${cardNumber}"${blockKey !== null ? ` data-block="${blockKey}"` : ''} onblur="updateValue(this)" onfocus="selectValue()" readonly value="${blockAmount}">`;
+                row.dataset.pull = totalAmount >= 4;
                 row.dataset.rarity = cardRarity;
 
                 if (setElement.url) {

--- a/js/index.js
+++ b/js/index.js
@@ -213,8 +213,9 @@ document.addEventListener("DOMContentLoaded", function (event) {
                             mainInput.dataset.block = cardBlock;
                             mainInput.value = collection[setId][cardId].amount?.[cardBlock] ?? 0;
                             mainInput.setAttribute('value', mainInput.value);
+                            mainInput.closest('.amount-card-wrapper')?.insertAdjacentHTML('afterend', getBlockBadge(cardBlock)) || mainInput.insertAdjacentHTML('afterend', getBlockBadge(cardBlock));
                         } else if ( !cardRow.querySelector(`.amount-card[data-block="${cardBlock}"]`) ) {
-                            cardRow.cells[1].innerHTML += `<input class="amount-card amount-card--reprint" type="text" data-card-number="${cardNumber}" data-block="${cardBlock}" onblur="updateValue(this)" onfocus="selectValue()" readonly value="${collection[setId][cardId].amount?.[cardBlock] || 0}">`;
+                            cardRow.cells[1].insertAdjacentHTML('beforeend', `<div class="amount-card-wrapper"><input class="amount-card amount-card--reprint" type="text" data-card-number="${cardNumber}" data-block="${cardBlock}" onblur="updateValue(this)" onfocus="selectValue()" readonly value="${collection[setId][cardId].amount?.[cardBlock] || 0}">${getBlockBadge(cardBlock)}</div>`);
                         }
                     }
                 }
@@ -340,7 +341,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                 const blockKey = setElement.block !== undefined ? String(setElement.block) : null;
                 const blockAmount = blockKey !== null ? (collection[setElement.id][cardId].amount[blockKey] ?? 0) : 0;
                 const totalAmount = Object.values(collection[setElement.id][cardId].amount).reduce((a, b) => a + b, 0);
-                row.insertCell(1).innerHTML = `<input class="amount-card" type="text" data-card-number="${cardNumber}"${blockKey !== null ? ` data-block="${blockKey}"` : ''} onblur="updateValue(this)" onfocus="selectValue()" readonly value="${blockAmount}">`;
+                row.insertCell(1).innerHTML = `<div class="amount-card-wrapper"><input class="amount-card" type="text" data-card-number="${cardNumber}"${blockKey !== null ? ` data-block="${blockKey}"` : ''} onblur="updateValue(this)" onfocus="selectValue()" readonly value="${blockAmount}">${blockKey !== null ? getBlockBadge(blockKey) : ''}</div>`;
                 row.dataset.pull = totalAmount >= 4;
                 row.dataset.rarity = cardRarity;
 

--- a/js/modal.js
+++ b/js/modal.js
@@ -195,20 +195,19 @@ const saveSet = () => {
 const updateValue = (element) => {
     element.setAttribute('value', element.value);
     const [set, id] = element.dataset.cardNumber.split('-');
-    if ( element.classList.contains('amount-card--reprint') ) {
-        const block = element.dataset.block;
-        if ( element.value > 0 ) {
-            (collection[set][id].reprint ??= {})[block] = parseInt(element.value);
-        } else if ( collection[set][id].reprint ) {
-            delete collection[set][id].reprint[block];
-            if ( Object.keys(collection[set][id].reprint).length === 0 ) {
-                delete collection[set][id].reprint;
-            }
+    const block = element.dataset.block;
+    const value = parseInt(element.value) || 0;
+
+    if ( block !== undefined ) {
+        if ( value > 0 ) {
+            (collection[set][id].amount ??= {})[block] = value;
+        } else {
+            delete (collection[set][id].amount ??= {})[block];
         }
-    } else {
-        element.parentElement.parentElement.dataset.pull = element.value >= 4;
-        collection[set][id].amount = parseInt(element.value);
     }
+
+    const total = Object.values(collection[set][id].amount ?? {}).reduce((a, b) => a + b, 0);
+    element.closest('tr').dataset.pull = total >= 4;
 }
 
 const selectValue = () => {

--- a/js/updates.js
+++ b/js/updates.js
@@ -1,3 +1,55 @@
+const migrateAmountToBlocks = () => {
+    let migrated = false;
+
+    // Construir mapa cardNumber -> bloque más bajo a partir de sets con id: null
+    const cardBlockMap = {};
+    sets.forEach(s => {
+        if (s.id === null && s.block !== undefined && s.cards) {
+            Object.keys(s.cards).forEach(cardNumber => {
+                const block = getCardBlock(cardNumber, s.block);
+                if (block !== null) {
+                    if (cardBlockMap[cardNumber] === undefined || block < cardBlockMap[cardNumber]) {
+                        cardBlockMap[cardNumber] = block;
+                    }
+                }
+            });
+        }
+    });
+
+    for (const setId in collection) {
+        if (typeof collection[setId] !== 'object' || setId === 'products') continue;
+        const setElement = sets.find(s => s.id === setId);
+        if (!setElement) continue;
+
+        for (const cardId in collection[setId]) {
+            const card = collection[setId][cardId];
+            if (typeof card.amount !== 'number') continue;
+
+            const cardNumber = `${setId}-${cardId}`;
+            const block = getCardBlock(cardNumber, setElement.block) ?? cardBlockMap[cardNumber] ?? null;
+            const newAmount = {};
+
+            if (block !== null && card.amount > 0) {
+                newAmount[String(block)] = card.amount;
+            }
+
+            if (card.reprint && typeof card.reprint === 'object') {
+                for (const b in card.reprint) {
+                    if (card.reprint[b] > 0) {
+                        newAmount[b] = (newAmount[b] || 0) + card.reprint[b];
+                    }
+                }
+                delete card.reprint;
+            }
+
+            card.amount = newAmount;
+            migrated = true;
+        }
+    }
+
+    return migrated;
+};
+
 const migrateReprints = () => {
     const collectionJson = JSON.parse(localStorage.getItem('collection') || '{}');
     const reprintBlocks = {};

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,0 +1,9 @@
+const getCardBlock = (cardId, block) => {
+    if (typeof block === 'number') return block;
+    if (!block) return null;
+    const setPrefix = cardId.replace(/-\d+$/, '');
+    for (const [b, entries] of Object.entries(block)) {
+        if (entries.includes(cardId) || entries.includes(setPrefix)) return Number(b);
+    }
+    return null;
+};

--- a/js/utils.js
+++ b/js/utils.js
@@ -9,6 +9,6 @@ const getCardBlock = (cardId, block) => {
 };
 
 const getBlockBadge = (block) => {
-    if (block === null || block === undefined) return '';
-    return `<span class="block-badge">${block}</span>`;
+    if (block === null || block === undefined || Number(block) === 0) return '';
+    return `<span class="block-badge">${String(block).padStart(2, '0')}</span>`;
 };

--- a/js/utils.js
+++ b/js/utils.js
@@ -7,3 +7,8 @@ const getCardBlock = (cardId, block) => {
     }
     return null;
 };
+
+const getBlockBadge = (block) => {
+    if (block === null || block === undefined) return '';
+    return `<span class="block-badge">${block}</span>`;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
 	"name": "dtcg-web-collection",
-	"version": "1.1.1",
+	"version": "1.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dtcg-web-collection",
-			"version": "1.1.1",
+			"version": "1.4.0",
+			"license": "MIT",
 			"devDependencies": {
 				"gulp": "^4.0.2",
 				"gulp-autoprefixer": "^8.0.0",
@@ -552,9 +553,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001710",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001710.tgz",
-			"integrity": "sha512-B5C0I0UmaGqHgo5FuqJ7hBd4L57A4dDD+Xi+XX1nXOoxGeDdY4Ko38qJYOyqznBVJEqON5p8P1x5zRR3+rsnxA==",
+			"version": "1.0.30001793",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+			"integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
 			"dev": true,
 			"funding": [
 				{
@@ -5559,9 +5560,9 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001710",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001710.tgz",
-			"integrity": "sha512-B5C0I0UmaGqHgo5FuqJ7hBd4L57A4dDD+Xi+XX1nXOoxGeDdY4Ko38qJYOyqznBVJEqON5p8P1x5zRR3+rsnxA==",
+			"version": "1.0.30001793",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+			"integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
 			"dev": true
 		},
 		"chalk": {

--- a/sass/_amount.scss
+++ b/sass/_amount.scss
@@ -9,6 +9,11 @@
     text-align: center;
     padding: 0;
 }
+
+.amount-card-wrapper {
+    position: relative;
+    display: inline-block;
+}
 .amount-card[value=""] {
     background-color: transparent;
 }

--- a/sass/_block-badge.scss
+++ b/sass/_block-badge.scss
@@ -8,10 +8,10 @@
     justify-content: center;
     background: white;
     color: black;
-    font-size: 0.6em;
+    font-size: 0.65em;
     font-weight: 700;
-    width: 18px;
-    height: 12px;
+    width: 10px;
+    height: 10px;
     clip-path: polygon(15% 0%, 85% 0%, 100% 50%, 85% 100%, 15% 100%, 0% 50%);
     pointer-events: none;
 }

--- a/sass/_block-badge.scss
+++ b/sass/_block-badge.scss
@@ -1,0 +1,17 @@
+.block-badge {
+    position: absolute;
+    bottom: 4px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: white;
+    color: black;
+    font-size: 0.6em;
+    font-weight: 700;
+    width: 18px;
+    height: 12px;
+    clip-path: polygon(15% 0%, 85% 0%, 100% 50%, 85% 100%, 15% 100%, 0% 50%);
+    pointer-events: none;
+}

--- a/sass/_block-badge.scss
+++ b/sass/_block-badge.scss
@@ -10,7 +10,7 @@
     color: black;
     font-size: 0.65em;
     font-weight: 700;
-    width: 10px;
+    width: 20px;
     height: 10px;
     clip-path: polygon(15% 0%, 85% 0%, 100% 50%, 85% 100%, 15% 100%, 0% 50%);
     pointer-events: none;

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -1,6 +1,7 @@
 @import "base";
 @import "card";
 @import "amount";
+@import "block-badge";
 @import "buttons";
 @import "icons";
 @import "filters";


### PR DESCRIPTION
Cambio MAJOR: `amount` pasa de número a mapa por bloque, eliminando el campo `reprint`.

## Cambios

- Extrae `getCardBlock` y `getBlockBadge` a `js/utils.js`
- Cambia inicialización de `amount` de número a objeto `{}`
- Lee `blockAmount` por clave de bloque en el input principal
- Actualiza `value` del input principal en `drawAlternatives` al asignar `data-block`
- Unifica `updateValue`: guarda en `amount[block]` sin distinción por clase
- Añade `migrateAmountToBlocks` en `updates.js` con `cardBlockMap` para sets sin `block` (P, LM)
- Envuelve cada input en `.amount-card-wrapper` para posicionamiento relativo
- Añade badge de bloque con forma de hexágono (oculto para bloque 0, formato 2 dígitos)

Closes #37