### PR TITLE
feat: soporte para tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 localstorage
 manifest.json
 node_modules
+sources/tokens/

--- a/css/style.css
+++ b/css/style.css
@@ -709,6 +709,10 @@ button.accordion.active:after {
     transform: scale(1);
   }
 }
+.custom-token--hidden {
+  display: none !important;
+}
+
 .content {
   height: calc(100vh - 175px);
   overflow: scroll;
@@ -953,6 +957,9 @@ td {
   display: flex;
   justify-content: space-evenly;
   align-items: center;
+}
+.card-info[hidden] {
+  display: none;
 }
 
 #card-status,

--- a/index.html
+++ b/index.html
@@ -117,6 +117,8 @@
                 <option value="collection">colección individual</option>
                 <option value="all">todas las colecciones</option>
             </select>
+            <label for="showCustomTokens">Tokens custom</label>
+            <input type="checkbox" id="showCustomTokens" onchange="toggleCustomTokens(this)">
         </div>
     </div>
     <div id="content" class="content">

--- a/js/data/data_2022.js
+++ b/js/data/data_2022.js
@@ -806,7 +806,7 @@ const data2022 = [
         "url": "bandaitcgplusURL/P/e_setID-cardIDparallel.png",
         "cards": {
             "BT2-051": "P_D",
-            "BT2-082": "_t_D",
+            "BT2-082": "_t_D", // TODO: Mover a Tokens como T-02?
             "BT7-110": "P_D",
         },
         "rarities": {

--- a/js/data/data_2024.js
+++ b/js/data/data_2024.js
@@ -226,14 +226,14 @@ const data2024 = [
         "release": "February, 2024",
         "url": "bandaitcgplusURL/PB/e_setID-cardID_PB_D.png",
         "cards": {
-            "BT2-082": "",
+            "BT2-082": "", // TODO: Mover a Tokens como T-02?
             "BT5-085": "",
             "P-114": "",
         },
         "override": {
             "url": "digimonFandom/7/71/BT2-Diaboromon_Token_P2.png",
             "cards": {
-                "BT2-082": "",
+                "BT2-082": "", // TODO: Mover a Tokens como T-02?
             }
         },
         "info_url": "https://world.digimoncard.com/products/goods/tamer-goods-set_PB16.php"

--- a/js/data/data_2025.js
+++ b/js/data/data_2025.js
@@ -1661,7 +1661,16 @@ const data2025 = [
             "BT22-043": "",
             "BT22-044": "",
             "BT22-054": "",
-            // https://world.digimoncard.com/images/cardlist/card/BT22-TOKEN.png
+            "T-002": "",
+        },
+        "override": {
+            "url": "digimoncardURL/BT22-TOKEN.png",
+            "cards": {
+                "T-002": "",
+            }
+        },
+        "rarities": {
+            "T": "t",
         },
         "info_url": "https://world.digimoncard.com/products/pack/ver22/",
     },
@@ -1874,9 +1883,15 @@ const data2025 = [
         "release": "September 1 – October 31, 2025",
         "url": "bandaitcgplusURL/P/e_setID-cardIDEC_D.png",
         "cards": {
-            // TODO: TOKEN
-            // "BT9-109": "",
+            "T-001": "",
         },
+        "override": {
+            "url": "digimoncardURL/TOKEN.png",
+            "cards": {
+                "T-001": "",
+            }
+        },
+        "rarity": "t",
         "info_url": "https://world.digimoncard.com/event/2025/evolution-cup/02/",
     },
     // Evolution Cup 2025 Vol. 2 Top 4 --- evolution_cup_2025_2_top4
@@ -2513,7 +2528,7 @@ const data2025 = [
             "BT23-040": "P_D",
             "BT23-048": "P_D",
             "BT23-061": "P_D",
-            // https://world.digimoncard.com/images/cardlist/card/BT23-TOKEN.png
+            "T-003": "",
             "P-207": "_D",
             "P-208": "_D",
             "P-209": "_D",
@@ -2521,11 +2536,15 @@ const data2025 = [
             "P-211": "_D",
             "P-212": "_D",
         },
+        "override": {
+            "url": "digimoncardURL/BT23-TOKEN.png",
+            "cards": {
+                "T-003": "",
+            }
+        },
         "rarities": {
-            // "BT23": {
-            //     "t": ["token"]
-            // },
-            "P": "p"
+            "P": "p",
+            "T": "t",
         },
         "info_url": "https://world.digimoncard.com/products/pack/ver22/",
     },
@@ -2597,8 +2616,22 @@ const data2025 = [
             "u": [8,9,11],
             "r": [4,7],
             "sr": [2,5,6,10,"12-14"],
-            // TODO: tiene 2 tokens
         }
+    },
+    // Advanced Deck Amethyst Mandala [ST-22] --- st22
+    {
+        "id": null,
+        "block": 5,
+        "slug": "st22",
+        "name": "Advanced Deck Amethyst Mandala [ST-22]",
+        "release": "December 5, 2025",
+        "url": "digimoncardURL/ST22-TOKENparallel.png",
+        "cards": {
+            "T-005": "01",
+            "T-006": "02",
+        },
+        "rarity": "t",
+        "info_url": "https://world.digimoncard.com/products/deck/st-22/",
     },
     // Advanced Deck Amethyst Mandala [ST-22] - Lucky Deck --- st22_lucky
     {

--- a/js/data/data_2025.js
+++ b/js/data/data_2025.js
@@ -1661,12 +1661,12 @@ const data2025 = [
             "BT22-043": "",
             "BT22-044": "",
             "BT22-054": "",
-            "T-002": "",
+            "T-08": "",
         },
         "override": {
             "url": "digimoncardURL/BT22-TOKEN.png",
             "cards": {
-                "T-002": "",
+                "T-08": "",
             }
         },
         "rarities": {
@@ -1883,12 +1883,12 @@ const data2025 = [
         "release": "September 1 – October 31, 2025",
         "url": "bandaitcgplusURL/P/e_setID-cardIDEC_D.png",
         "cards": {
-            "T-001": "",
+            "T-02": "",
         },
         "override": {
             "url": "digimoncardURL/TOKEN.png",
             "cards": {
-                "T-001": "",
+                "T-02": "",
             }
         },
         "rarity": "t",
@@ -2528,7 +2528,7 @@ const data2025 = [
             "BT23-040": "P_D",
             "BT23-048": "P_D",
             "BT23-061": "P_D",
-            "T-003": "",
+            "T-15": "",
             "P-207": "_D",
             "P-208": "_D",
             "P-209": "_D",
@@ -2539,7 +2539,7 @@ const data2025 = [
         "override": {
             "url": "digimoncardURL/BT23-TOKEN.png",
             "cards": {
-                "T-003": "",
+                "T-15": "",
             }
         },
         "rarities": {
@@ -2627,8 +2627,8 @@ const data2025 = [
         "release": "December 5, 2025",
         "url": "digimoncardURL/ST22-TOKENparallel.png",
         "cards": {
-            "T-005": "01",
-            "T-006": "02",
+            "T-10": "01",
+            "T-14": "02",
         },
         "rarity": "t",
         "info_url": "https://world.digimoncard.com/products/deck/st-22/",

--- a/js/data/data_2026.js
+++ b/js/data/data_2026.js
@@ -239,12 +239,12 @@ const data2026 = [
             "BT24-044": "P_D",
             "BT24-054": "P_D",
             "BT24-067": "P_D",
-            "T-004": "",
+            "T-16": "",
         },
         "override": {
             "url": "digimoncardURL/BT24-TOKEN.png",
             "cards": {
-                "T-004": "",
+                "T-16": "",
             }
         },
         "rarities": {

--- a/js/data/data_2026.js
+++ b/js/data/data_2026.js
@@ -239,13 +239,17 @@ const data2026 = [
             "BT24-044": "P_D",
             "BT24-054": "P_D",
             "BT24-067": "P_D",
-            // https://world.digimoncard.com/images/products/pack/ver24/card/BT24_TOKEN.png
+            "T-004": "",
+        },
+        "override": {
+            "url": "digimoncardURL/BT24-TOKEN.png",
+            "cards": {
+                "T-004": "",
+            }
         },
         "rarities": {
-            // "BT24": {
-            //     "t": ["token"]
-            // },
-            "P": "p"
+            "P": "p",
+            "T": "t",
         },
         "info_url": "https://world.digimoncard.com/products/pack/ver24/",
     },

--- a/js/data/data_norelease.js
+++ b/js/data/data_norelease.js
@@ -132,7 +132,31 @@ const dataNoRelease = [
         "url": "digimoncardTokenURL/token_cardID.webp",
         "add_zero": 2,
         "info_url": "https://world.digimoncard.com/rule/#download",
-        "color": {},
+        "color": {
+            "red": [3,11],
+            "yellow": [4,8,10,12,14],
+            "green": [13],
+            "black": [7],
+            "purple": [5,6,9],
+            "white": [1,2,"15-17"]
+        },
+        // T-01: TOKEN CARD
+        // T-02: Diaboromon
+        // T-03: Amon of Crimson Flame
+        // T-04: Umon of Blue Thunder
+        // T-05: Gyuukimon
+        // T-06: Fujitsumon
+        // T-07: KoHagurumon
+        // T-08: Familiar
+        // T-09: Volée＆Zerdrücken
+        // T-10: Pipe Fox
+        // T-11: WarGrowlmon
+        // T-12: Taomon
+        // T-13: Rapidmon
+        // T-14: Uka no Mitama
+        // T-15: Atho, René & Por
+        // T-16: Petrification
+        // T-17: Hinukamuy
         "rarity": "t"
     },
     // Custom Tokens --- t_custom

--- a/js/data/data_norelease.js
+++ b/js/data/data_norelease.js
@@ -122,4 +122,38 @@ const dataNoRelease = [
             "sec": [111,112]
         }
     },
+    // Tokens
+    {
+        "id": "T",
+        "name": "Tokens",
+        "release": null,
+        "total": 6,
+        "url": null,
+        "add_zero": 3,
+        "info_url": null,
+        "color": {},
+        "rarity": "t"
+    },
+    // Bandai Printable Tokens --- t_bandai_printable
+    {
+        "id": null,
+        "slug": "t_bandai_printable",
+        "name": "Bandai Printable Tokens",
+        "release": null,
+        "url": "noCardURL",
+        "cards": {},
+        "rarity": "t",
+        "info_url": null,
+    },
+    // Custom Tokens --- t_custom
+    {
+        "id": null,
+        "slug": "t_custom",
+        "name": "Custom Tokens",
+        "release": null,
+        "url": "noCardURL",
+        "cards": {},
+        "rarity": "t",
+        "info_url": null,
+    },
 ];

--- a/js/data/data_norelease.js
+++ b/js/data/data_norelease.js
@@ -159,15 +159,4 @@ const dataNoRelease = [
         // T-17: Hinukamuy
         "rarity": "t"
     },
-    // Custom Tokens --- t_custom
-    {
-        "id": null,
-        "slug": "t_custom",
-        "name": "Custom Tokens",
-        "release": null,
-        "url": "noCardURL",
-        "cards": {},
-        "rarity": "t",
-        "info_url": null,
-    },
 ];

--- a/js/data/data_norelease.js
+++ b/js/data/data_norelease.js
@@ -127,23 +127,13 @@ const dataNoRelease = [
         "id": "T",
         "name": "Tokens",
         "release": null,
-        "total": 6,
-        "url": null,
-        "add_zero": 3,
-        "info_url": null,
+        "total": 17,
+        "slug": "t",
+        "url": "digimoncardTokenURL/token_cardID.webp",
+        "add_zero": 2,
+        "info_url": "https://world.digimoncard.com/rule/#download",
         "color": {},
         "rarity": "t"
-    },
-    // Bandai Printable Tokens --- t_bandai_printable
-    {
-        "id": null,
-        "slug": "t_bandai_printable",
-        "name": "Bandai Printable Tokens",
-        "release": null,
-        "url": "noCardURL",
-        "cards": {},
-        "rarity": "t",
-        "info_url": null,
     },
     // Custom Tokens --- t_custom
     {

--- a/js/index.js
+++ b/js/index.js
@@ -418,4 +418,25 @@ document.addEventListener("DOMContentLoaded", function (event) {
         document.querySelector(`button[value="${setId}"]`)?.classList.add('active');
     }
     updateFilterCount();
+
+    // Cargar tokens custom desde manifest local (solo visual, sin localStorage)
+    fetch('sources/tokens/manifest.json')
+        .then(r => r.ok ? r.json() : Promise.reject())
+        .then(manifest => {
+            if (!manifest.length) return;
+            const hidden = !document.getElementById('showCustomTokens').checked;
+            manifest.forEach(token => {
+                const row = document.getElementById(token.id);
+                if (!row) return;
+                const cardList = row.getElementsByClassName('card_list')[0];
+                const imgs = token.files.map(file =>
+                    `<img loading="lazy" class="card custom-token${hidden ? ' custom-token--hidden' : ''}" src="sources/tokens/${token.id}/${file}" title="${token.id}: Custom token" alt="${token.id}: Custom token" data-set="t_custom" onclick="viewCustomToken(this)" onerror="this.onerror=null;this.src='/sources/error_card.png';">`
+                ).join('');
+                cardList.innerHTML += imgs;
+            });
+            document.getElementById('showCustomTokens').disabled = false;
+        })
+        .catch(() => {
+            document.getElementById('showCustomTokens').disabled = true;
+        });
 });

--- a/js/index.js
+++ b/js/index.js
@@ -71,6 +71,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
 
         const bandaitcgplusURL = 'https://files.bandai-tcg-plus.com/card_image/DG-EN';
         const digimoncardURL = 'https://world.digimoncard.com/images/cardlist/card';
+        const digimoncardTokenURL = 'https://world.digimoncard.com/images/rule/token';
         const digimoncardjpURL = 'https://digimoncard.com/images/cardlist/card';
         const digimonCardDev = 'https://assets.cardlist.dev/images/communitycards';
         const digimonFandom = 'https://static.wikia.nocookie.net/digimoncardgame/images';
@@ -79,6 +80,8 @@ document.addEventListener("DOMContentLoaded", function (event) {
             var cardUrl = url.replace('bandaitcgplusURL', bandaitcgplusURL);
         } else if (url.includes('digimoncardjpURL')) {
             var cardUrl = url.replace('digimoncardjpURL', digimoncardjpURL);
+        } else if (url.includes('digimoncardTokenURL')) {
+            var cardUrl = url.replace('digimoncardTokenURL', digimoncardTokenURL);
         } else if (url.includes('digimoncardURL')) {
             var cardUrl = url.replace('digimoncardURL', digimoncardURL);
         } else if (url.includes('digimonCardDev')) {

--- a/js/modal.js
+++ b/js/modal.js
@@ -89,7 +89,7 @@ const modalClose = (element) => {
 const modalOk = () => {
     const editModal = document.getElementById('editModal');
     const status = parseInt(document.querySelector('input[name="status"]:checked').value);
-    const price = parseFloat(document.getElementById('price').value || 0);
+    const price = parseFloat(document.getElementById('price').value || 0); // TODO: normalizar separador decimal (. o ,) antes de parsear (#57)
     const cardId = document.getElementById('cardId').value;
 
     if ( 'card' === typeEdit ) {
@@ -109,7 +109,7 @@ const modalOk = () => {
     document.getElementById(cardId).setAttribute('data-bought', status > 1 ? price : 0);
 
     const cardmarketUrl = document.getElementById('cardmarketUrl').value || '';
-    const cardmarketPrice = parseFloat( document.getElementById('cardmarketPrice').value || 0 );
+    const cardmarketPrice = parseFloat( document.getElementById('cardmarketPrice').value || 0 ); // TODO: normalizar separador decimal (. o ,) antes de parsear (#57)
 
     if ( cardmarketUrl !== '' || cardmarketPrice !== 0 ) {
         if ( cardmarketUrl !== '' ) {

--- a/js/modal.js
+++ b/js/modal.js
@@ -43,6 +43,8 @@ const modalOpen = (element) => {
         document.getElementById('cardmarketUrl').value = element.dataset.cardmarketurl || '';
         document.getElementById('cardmarketPrice').value = element.dataset.cardmarketprice || '';
     } else {
+        const cardInfo = modal.querySelector('.card-info');
+        cardInfo.hidden = false;
         const cardStatus = document.getElementById('card-status');
         const cardPrice = document.getElementById('card-price');
         const cardMinimum = document.getElementById('card-minimum');
@@ -220,3 +222,12 @@ const priceConfirm = () => {
     document.getElementById('priceConfirm').hidden = false;
     document.getElementById('price').select();
 }
+
+const viewCustomToken = (element) => {
+    const modal = document.getElementById('viewModal');
+    modal.querySelector('.modal-title').innerHTML = element.title;
+    modal.querySelector('.modal-card').src = element.src;
+    modal.querySelector('.modal-card').alt = element.alt;
+    modal.querySelector('.card-info').hidden = true;
+    modal.classList.add('open');
+};

--- a/js/updates.js
+++ b/js/updates.js
@@ -1,4 +1,4 @@
-const DATA_VERSION = 3;
+const DATA_VERSION = 4;
 
 const runMigrations = () => {
     const currentVersion = parseInt(localStorage.getItem('dataVersion') || '0');
@@ -8,7 +8,8 @@ const runMigrations = () => {
         { version: 1, fn: migrateAmountToBlocks },
         { version: 2, fn: migrateRemoveWrongPromos },
         { version: 3, fn: migrateTokenIds },
-        // TODO v4: no almacenar cartas con estado por defecto ({ status: 0, bought: 0 }) para reducir tamaño de localStorage (#29)
+        { version: 4, fn: migrateCleanTokenResidual },
+        // TODO: no almacenar cartas con estado por defecto ({ status: 0, bought: 0 }) para reducir tamaño de localStorage (#29)
     ];
 
     migrations
@@ -90,6 +91,14 @@ const migrateTokenIds = () => {
         }
     });
     // Eliminar IDs que ya no existen (T-001..T-006 incorrectos, ahora son T-02,T-08,T-10,T-14,T-15,T-16)
+    const validIds = Array.from({length: 17}, (_, i) => String(i + 1).padStart(2, '0'));
+    Object.keys(collection['T']).forEach(id => {
+        if (!validIds.includes(id)) delete collection['T'][id];
+    });
+};
+
+const migrateCleanTokenResidual = () => {
+    if (!collection['T']) return;
     const validIds = Array.from({length: 17}, (_, i) => String(i + 1).padStart(2, '0'));
     Object.keys(collection['T']).forEach(id => {
         if (!validIds.includes(id)) delete collection['T'][id];

--- a/js/updates.js
+++ b/js/updates.js
@@ -1,4 +1,4 @@
-const DATA_VERSION = 2;
+const DATA_VERSION = 3;
 
 const runMigrations = () => {
     const currentVersion = parseInt(localStorage.getItem('dataVersion') || '0');
@@ -7,7 +7,8 @@ const runMigrations = () => {
     const migrations = [
         { version: 1, fn: migrateAmountToBlocks },
         { version: 2, fn: migrateRemoveWrongPromos },
-        // TODO v3: no almacenar cartas con estado por defecto ({ status: 0, bought: 0 }) para reducir tamaño de localStorage (#29)
+        { version: 3, fn: migrateTokenIds },
+        // TODO v4: no almacenar cartas con estado por defecto ({ status: 0, bought: 0 }) para reducir tamaño de localStorage (#29)
     ];
 
     migrations
@@ -75,5 +76,22 @@ const migrateRemoveWrongPromos = () => {
         if (!collection['P'][id]?.cards) return;
         delete collection['P'][id].cards['otp22'];
         delete collection['P'][id].cards['wp22'];
+    });
+};
+
+const migrateTokenIds = () => {
+    if (!collection['T']) return;
+    // Renombrar de 3 dígitos a 2 dígitos
+    Object.keys(collection['T']).forEach(id => {
+        if (id.length === 3) {
+            const newId = id.replace(/^0/, '');
+            collection['T'][newId] = collection['T'][id];
+            delete collection['T'][id];
+        }
+    });
+    // Eliminar IDs que ya no existen (T-001..T-006 incorrectos, ahora son T-02,T-08,T-10,T-14,T-15,T-16)
+    const validIds = Array.from({length: 17}, (_, i) => String(i + 1).padStart(2, '0'));
+    Object.keys(collection['T']).forEach(id => {
+        if (!validIds.includes(id)) delete collection['T'][id];
     });
 };

--- a/js/views.js
+++ b/js/views.js
@@ -1,3 +1,9 @@
+const toggleCustomTokens = (checkbox) => {
+    document.querySelectorAll('img.custom-token').forEach(img => {
+        img.classList.toggle('custom-token--hidden', !checkbox.checked);
+    });
+};
+
 const list = () => {
     const list = document.getElementById('list').value;
     const setLists = document.getElementById('setLists');

--- a/sass/_modal.scss
+++ b/sass/_modal.scss
@@ -197,6 +197,10 @@
   display: flex;
   justify-content: space-evenly;
   align-items: center;
+
+  &[hidden] {
+    display: none;
+  }
 }
 #card-status,
 #card-price,

--- a/sass/_views.scss
+++ b/sass/_views.scss
@@ -1,3 +1,7 @@
+.custom-token--hidden {
+    display: none !important;
+}
+
 .content {
     height: calc(100vh - 175px);
     overflow: scroll;


### PR DESCRIPTION
## Descripción

Implementa soporte completo para tokens (IMPROVEMENTS.md ítem 63).

Closes #59

## Cambios

### Set T (tokens oficiales)
- Crear set `T` con los 17 tokens oficiales de Bandai (tabla, colores, rareza, URLs)
- Datos de tokens incluidos en BT22, BT23, BT24, ST22, Evolution Cup 2025 Vol.2
- Migración v3: merge de `t_bandai_printable` en el set base T
- Nombres y colores de cada token

### Custom tokens (visualización local)
- Checkbox "Tokens custom" en la barra de vistas para mostrar/ocultar
- Fetch de `sources/tokens/manifest.json` al cargar la página
- Inyecta todas las imágenes de cada carpeta `T-XX/` en la fila del token correspondiente
- Click en imagen custom abre el viewModal (solo visualización, sin datos de colección)
- `sources/tokens/` ignorado en git (imágenes y manifest son locales)

### Fixes
- `.card-info[hidden]` ahora se oculta correctamente (override de `display: flex`)

### Otros
- TODO para reclasificación de BT2-082 como token
- TODO referencia al bug #57 (separador decimal)