### PR TITLE
fix: normalizar separador decimal en campos de precio

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@
             </div>
             <div class="price-confirm" hidden id="priceConfirm">
                 <label for="price">Precio</label>
-                <input type="number" name="price" id="price" step="0.01" onfocus="selectValue()">
+                <input type="text" name="price" id="price" inputmode="decimal" onfocus="selectValue()">
             </div>
             <div class="cardmarket" id="cardmarket">
                 <img src="https://static.cardmarket.com/img/526dbb9ae52c5e62404fe903e9769807/static/misc/favicon-96x96.png" alt="">

--- a/js/index.js
+++ b/js/index.js
@@ -432,7 +432,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                 const imgs = token.files.map(file =>
                     `<img loading="lazy" class="card custom-token${hidden ? ' custom-token--hidden' : ''}" src="sources/tokens/${token.id}/${file}" title="${token.id}: Custom token" alt="${token.id}: Custom token" data-set="t_custom" onclick="viewCustomToken(this)" onerror="this.onerror=null;this.src='/sources/error_card.png';">`
                 ).join('');
-                cardList.innerHTML += imgs;
+                cardList.insertAdjacentHTML('beforeend', imgs);
             });
             document.getElementById('showCustomTokens').disabled = false;
         })

--- a/js/index.js
+++ b/js/index.js
@@ -154,7 +154,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                     }
 
                     // TODO: añadir cardRarity
-                    cardRow.getElementsByClassName('card_list')[0].innerHTML += getImageTag(cardUrl, name, `${cardNumber}__${slug}`, slug, collection[setId][cardId].cards[slug].status, collection[setId][cardId].cards[slug].bought, undefined, getCardBlock(cardNumber, block));
+                    cardRow.getElementsByClassName('card_list')[0].insertAdjacentHTML('beforeend', getImageTag(cardUrl, name, `${cardNumber}__${slug}`, slug, collection[setId][cardId].cards[slug].status, collection[setId][cardId].cards[slug].bought, undefined, getCardBlock(cardNumber, block)));
                 }
             });
         } else {
@@ -191,7 +191,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                                 cardUrl = getImageUrl(setElement.override.url, setId, cardId, parallelElement);
                             }
 
-                            cardRow.getElementsByClassName('card_list')[0].innerHTML += getImageTag(cardUrl, name, `${cardNumber}__${slug}_${index}`, slug, collection[setId][cardId].cards[parallel_slug].status, collection[setId][cardId].cards[parallel_slug].bought, cardRarity, getCardBlock(cardNumber, block));
+                            cardRow.getElementsByClassName('card_list')[0].insertAdjacentHTML('beforeend', getImageTag(cardUrl, name, `${cardNumber}__${slug}_${index}`, slug, collection[setId][cardId].cards[parallel_slug].status, collection[setId][cardId].cards[parallel_slug].bought, cardRarity, getCardBlock(cardNumber, block)));
                         });
                     } else {
                         // 5. si no existe la carta, la añadimos al set
@@ -206,7 +206,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                             cardUrl = getImageUrl(setElement.override.url, setId, cardId, overrideParallel);
                         }
                         
-                        cardRow.getElementsByClassName('card_list')[0].innerHTML += getImageTag(cardUrl, name, `${cardNumber}__${slug}`, slug, collection[setId][cardId].cards[slug].status, collection[setId][cardId].cards[slug].bought, cardRarity, getCardBlock(cardNumber, block));
+                        cardRow.getElementsByClassName('card_list')[0].insertAdjacentHTML('beforeend', getImageTag(cardUrl, name, `${cardNumber}__${slug}`, slug, collection[setId][cardId].cards[slug].status, collection[setId][cardId].cards[slug].bought, cardRarity, getCardBlock(cardNumber, block)));
                     }
 
                     const cardBlock = getCardBlock(cardNumber, block);

--- a/js/modal.js
+++ b/js/modal.js
@@ -34,14 +34,14 @@ const modalOpen = (element) => {
         document.getElementById('cardId').value = element.id;
 
         if ( parseInt(element.dataset.status) > 1 ) {
-            document.getElementById('price').value = element.dataset.bought;
+            document.getElementById('price').value = element.dataset.bought.replace('.', ',');
             document.getElementById('priceConfirm').hidden = false;
         } else {
             document.getElementById('price').value = '';
             document.getElementById('priceConfirm').hidden = true;
         }
         document.getElementById('cardmarketUrl').value = element.dataset.cardmarketurl || '';
-        document.getElementById('cardmarketPrice').value = element.dataset.cardmarketprice || '';
+        document.getElementById('cardmarketPrice').value = element.dataset.cardmarketprice ? element.dataset.cardmarketprice.replace('.', ',') : '';
     } else {
         const cardInfo = modal.querySelector('.card-info');
         cardInfo.hidden = false;
@@ -91,7 +91,7 @@ const modalClose = (element) => {
 const modalOk = () => {
     const editModal = document.getElementById('editModal');
     const status = parseInt(document.querySelector('input[name="status"]:checked').value);
-    const price = parseFloat(document.getElementById('price').value || 0); // TODO: normalizar separador decimal (. o ,) antes de parsear (#57)
+    const price = Math.round(parseFloat((document.getElementById('price').value || '0').replace(',', '.')) * 100) / 100;
     const cardId = document.getElementById('cardId').value;
 
     if ( 'card' === typeEdit ) {
@@ -111,7 +111,7 @@ const modalOk = () => {
     document.getElementById(cardId).setAttribute('data-bought', status > 1 ? price : 0);
 
     const cardmarketUrl = document.getElementById('cardmarketUrl').value || '';
-    const cardmarketPrice = parseFloat( document.getElementById('cardmarketPrice').value || 0 ); // TODO: normalizar separador decimal (. o ,) antes de parsear (#57)
+    const cardmarketPrice = Math.round(parseFloat((document.getElementById('cardmarketPrice').value || '0').replace(',', '.')) * 100) / 100;
 
     if ( cardmarketUrl !== '' || cardmarketPrice !== 0 ) {
         if ( cardmarketUrl !== '' ) {

--- a/js/modal.js
+++ b/js/modal.js
@@ -88,10 +88,12 @@ const modalClose = (element) => {
     modal.classList.remove('open');
 };
 
+const parsePrice = (value) => Math.round(parseFloat((value || '0').replace(',', '.')) * 100) / 100;
+
 const modalOk = () => {
     const editModal = document.getElementById('editModal');
     const status = parseInt(document.querySelector('input[name="status"]:checked').value);
-    const price = Math.round(parseFloat((document.getElementById('price').value || '0').replace(',', '.')) * 100) / 100;
+    const price = parsePrice(document.getElementById('price').value);
     const cardId = document.getElementById('cardId').value;
 
     if ( 'card' === typeEdit ) {
@@ -111,7 +113,7 @@ const modalOk = () => {
     document.getElementById(cardId).setAttribute('data-bought', status > 1 ? price : 0);
 
     const cardmarketUrl = document.getElementById('cardmarketUrl').value || '';
-    const cardmarketPrice = Math.round(parseFloat((document.getElementById('cardmarketPrice').value || '0').replace(',', '.')) * 100) / 100;
+    const cardmarketPrice = parsePrice(document.getElementById('cardmarketPrice').value);
 
     if ( cardmarketUrl !== '' || cardmarketPrice !== 0 ) {
         if ( cardmarketUrl !== '' ) {


### PR DESCRIPTION
Closes #57

## Cambios

### Fix
- Normaliza coma → punto antes de `parseFloat` en ambos campos de precio
- Redondeo a 2 decimales con `Math.round(...*100)/100`
- Input de precio cambiado a `type="text" inputmode="decimal"` para permitir coma
- Precios mostrados con coma en el modal de edición

### Refactor
- Extraída función `parsePrice` para evitar repetición

### Perf
- Reemplazado `innerHTML +=` por `insertAdjacentHTML('beforeend')` en inyección de custom tokens y en `drawAlternatives` (evita re-parsear DOM existente)