### PR TITLE
feat: persistir filtros y vista entre recargas

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -1,3 +1,38 @@
+const SESSION_FILTERS_KEY = 'uiFilters';
+
+const saveFiltersToSession = () => {
+    const state = {
+        status: document.getElementById('status').value,
+        color: document.getElementById('color').value,
+        set: document.getElementById('setValue').value,
+        setLabel: document.getElementById('set').value,
+        rarity: document.getElementById('rarity').value,
+        block: document.getElementById('block').value,
+        list: document.getElementById('list').value,
+        show: document.getElementById('show').value,
+    };
+    sessionStorage.setItem(SESSION_FILTERS_KEY, JSON.stringify(state));
+};
+
+const restoreFiltersFromSession = () => {
+    const raw = sessionStorage.getItem(SESSION_FILTERS_KEY);
+    if (!raw) return;
+    const state = JSON.parse(raw);
+
+    document.getElementById('status').value = state.status || '';
+    document.getElementById('color').value = state.color || '';
+    document.getElementById('setValue').value = state.set || '';
+    document.getElementById('set').value = state.setLabel || '';
+    document.getElementById('rarity').value = state.rarity || '';
+    document.getElementById('block').value = state.block || '';
+    document.getElementById('list').value = state.list || 'table';
+    document.getElementById('show').value = state.show || 'collection';
+
+    list();
+    show();
+    filterCards();
+};
+
 const datalistNavigation = {
     'prev': null,
     'next': null,
@@ -191,6 +226,7 @@ const filterCards = () => {
     });
 
     updateFilterCount();
+    saveFiltersToSession();
 }
 
 const searchSet = (element) => {

--- a/js/index.js
+++ b/js/index.js
@@ -418,6 +418,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
         document.querySelector(`button[value="${setId}"]`)?.classList.add('active');
     }
     updateFilterCount();
+    restoreFiltersFromSession();
 
     // Cargar tokens custom desde manifest local (solo visual, sin localStorage)
     fetch('sources/tokens/manifest.json')

--- a/js/views.js
+++ b/js/views.js
@@ -10,6 +10,7 @@ const list = () => {
 
     setLists.classList.remove('view--table', 'view--grid');
     setLists.classList.add('view--' + list);
+    saveFiltersToSession();
 };
 
 const show = () => {
@@ -19,6 +20,7 @@ const show = () => {
     setLists.classList.remove('view--collection', 'view--all');
     setLists.classList.add('view--' + show);
     updateFilterCount();
+    saveFiltersToSession();
 }
 
 const downloadJson = (data) => {


### PR DESCRIPTION
Closes #14

## Cambios

Los filtros (estado, color, set, rareza, bloque) y las opciones de vista (listar como, mostrar) se guardan en `sessionStorage` cada vez que cambian y se restauran al recargar la página.

La sesión se limpia automáticamente al cerrar la pestaña.

## Archivos modificados

- `js/filters.js` — Funciones `saveFiltersToSession()` y `restoreFiltersFromSession()`
- `js/views.js` — `list()` y `show()` llaman a `saveFiltersToSession()`
- `js/index.js` — Llama a `restoreFiltersFromSession()` al final de `DOMContentLoaded`