### PR TITLE
feat: add "sin playset en bloque" filter option

### DIFF
--- a/UI.md
+++ b/UI.md
@@ -15,7 +15,7 @@ Reconstrucción de la UI a partir del código fuente, para referencia futura.
 ### 3. Barra de filtros
 
 Una línea con:
-- Select **Estado** (Cualquiera, Sin playset ni faltas, Sin playset, Falta, Obtenida, Reservada, Comprada, Proxy)
+- Select **Estado** (Cualquiera, Sin playset ni faltas, Sin playset general, Sin playset en bloque, Falta, Obtenida, Reservada, Comprada, Proxy)
 - Select **Color primario** (Todos, Rojo, Azul, Amarillo...)
 - Botón `<` | Input de búsqueda de set con datalist | Botón `>`
 - Select **Rareza** (Todos, AA, SP, SEC, SR, P, R, U, C, T)

--- a/css/style.css
+++ b/css/style.css
@@ -702,6 +702,9 @@ button.accordion.active:after {
 .filter--status--no_pull tbody tr[data-pull=true] {
   display: none;
 }
+.filter--status--no_pull_block tbody tr[data-pull-block=true] {
+  display: none;
+}
 .filter--status--no_pull_no_have tbody tr[data-pull=true]:not(.match_filter) {
   display: none;
 }

--- a/index.html
+++ b/index.html
@@ -51,7 +51,8 @@
             <select name="status" id="status" onchange="filterCards()">
                 <option value="">Cualquiera</option>
                 <option value="no_pull_no_have">Sin playset ni faltas</option>
-                <option value="no_pull">Sin playset</option>
+                <option value="no_pull">Sin playset general</option>
+                <option value="no_pull_block">Sin playset en bloque</option>
                 <option value="no_have">Falta</option>
                 <option value="got_it">Obtenida</option>
                 <option value="reservation">Reservada</option>
@@ -128,7 +129,7 @@
             </div>
         </div>
     </div>
-    <a href="https://paypal.me/vegekku/1.5" class="no-print" target="_blank">Un pañal para Ennis :)</a> | <span class="no-print">bandai: 5926 results</span> | <span class="no-print">Last update: June 5, 2026</span> | <a href="https://github.com/Vegekku/dtcg-web" class="no-print" target="_blank">GitHub</a>
+    <a href="https://paypal.me/vegekku/1.5" class="no-print" target="_blank">Un pañal para Ennis :)</a> | <span class="no-print">bandai: 5926 results</span> | <span class="no-print">Last update: Jul 3, 2026</span> | <a href="https://github.com/Vegekku/dtcg-web" class="no-print" target="_blank">GitHub</a>
     
     <div class="modal" id="editModal">
         <div class="modal-bg modal-exit" onclick="modalClose(this)"></div>

--- a/js/filters.js
+++ b/js/filters.js
@@ -79,7 +79,7 @@ const filterCards = () => {
             row.classList.remove('match_filter', 'match_filter--status');
         });
 
-        setLists.classList.remove('filter--status', 'filter--status--no_pull', 'filter--status--no_pull_no_have');
+        setLists.classList.remove('filter--status', 'filter--status--no_pull', 'filter--status--no_pull_block', 'filter--status--no_pull_no_have');
         content.className = 'content';
     }
     cleanFilterStatus();
@@ -100,6 +100,9 @@ const filterCards = () => {
         } else if ('no_pull' === filters.status) {
             setLists.classList.add('filter--status--no_pull');
             content.classList.add('filter--status--no_pull');
+        } else if ('no_pull_block' === filters.status) {
+            setLists.classList.add('filter--status--no_pull_block');
+            content.classList.add('filter--status--no_pull_block');
         } else {
             setLists.classList.add('filter--status');
             content.classList.add('filter--status', `status--${filters.status}`);
@@ -213,6 +216,8 @@ const filterCards = () => {
             if (filters.block !== '' && !row.classList.contains('match_filter--block')) match = false;
             if (filters.status === 'no_pull') {
                 if (row.dataset.pull === 'true') match = false;
+            } else if (filters.status === 'no_pull_block') {
+                if (row.dataset.pullBlock === 'true') match = false;
             } else if (filters.status === 'no_pull_no_have') {
                 if (row.dataset.pull === 'true' && !row.classList.contains('match_filter')) match = false;
             } else if (filters.status !== '') {

--- a/js/index.js
+++ b/js/index.js
@@ -220,6 +220,10 @@ document.addEventListener("DOMContentLoaded", function (event) {
                         } else if ( !cardRow.querySelector(`.amount-card[data-block="${cardBlock}"]`) ) {
                             cardRow.cells[1].insertAdjacentHTML('beforeend', `<div class="amount-card-wrapper"><input class="amount-card amount-card--reprint" type="text" data-card-number="${cardNumber}" data-block="${cardBlock}" onblur="updateValue(this)" onfocus="selectValue()" readonly value="${collection[setId][cardId].amount?.[cardBlock] || 0}">${getBlockBadge(cardBlock)}</div>`);
                         }
+                        if (cardRow.dataset.pullBlock !== 'false') {
+                            const blockAmount = collection[setId][cardId].amount?.[cardBlock] ?? 0;
+                            if (blockAmount < 4) cardRow.dataset.pullBlock = false;
+                        }
                     }
                 }
             });
@@ -347,6 +351,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                 const totalAmount = Object.values(collection[setElement.id][cardId].amount).reduce((a, b) => a + b, 0);
                 row.insertCell(1).innerHTML = `<div class="amount-card-wrapper"><input class="amount-card" type="text" data-card-number="${cardNumber}"${blockKey !== null ? ` data-block="${blockKey}"` : ''} onblur="updateValue(this)" onfocus="selectValue()" readonly value="${blockAmount}">${blockKey !== null ? getBlockBadge(blockKey) : ''}</div>`;
                 row.dataset.pull = totalAmount >= 4;
+                row.dataset.pullBlock = blockKey !== null ? blockAmount >= 4 : totalAmount >= 4;
                 row.dataset.rarity = cardRarity;
 
                 if (setElement.url) {

--- a/sass/_filters.scss
+++ b/sass/_filters.scss
@@ -68,6 +68,11 @@
             display: none;
         }
     }
+    &--no_pull_block {
+        tbody tr[data-pull-block="true"] {
+            display: none;
+        }
+    }
     &--no_pull_no_have {
         tbody tr[data-pull="true"]:not(.match_filter) {
             display: none;


### PR DESCRIPTION
## Summary

Add a new filter option "Sin playset en bloque" that shows cards missing a playset in at least one individual block, complementing the existing global playset filter.

## Changes

- `js/index.js` — assign `data-pull-block` on row creation; update in `drawAlternatives` with early return optimization
- `js/filters.js` — add `no_pull_block` branch in `filterCards` and table visibility logic; add class to cleanup
- `index.html` — rename "Sin playset" to "Sin playset general"; add "Sin playset en bloque" option
- `sass/_filters.scss` + `css/style.css` — add CSS rule to hide rows with `data-pull-block="true"`
- `UI.md` — update Estado select options

Closes #69