### PR TITLE
fix: modal close button misaligned with container padding and overlapping title

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -870,8 +870,13 @@ td {
   padding: 20px;
   max-width: 450px;
 }
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
 .modal-title {
-  margin-top: 0;
+  margin: 0;
   font-size: 1.2em;
 }
 .modal-card {
@@ -902,14 +907,12 @@ td {
   border-radius: 10px;
 }
 .modal-close {
-  position: absolute;
-  right: 10px;
-  top: 10px;
   outline: none;
   -webkit-appearance: none;
      -moz-appearance: none;
           appearance: none;
   color: red;
+  flex-shrink: 0;
 }
 .modal input[type=radio],
 .modal input[type=radio] + label {

--- a/css/style.css
+++ b/css/style.css
@@ -868,6 +868,7 @@ td {
   background: #fff;
   position: relative;
   padding: 20px;
+  width: 100%;
   max-width: 450px;
 }
 .modal-header {

--- a/css/style.css
+++ b/css/style.css
@@ -916,6 +916,7 @@ td {
   flex-shrink: 0;
   border-radius: 50%;
   padding: 12px;
+  margin: -12px -12px -12px 0;
   transition: background-color 0.2s, color 0.2s;
 }
 .modal-close:hover {

--- a/css/style.css
+++ b/css/style.css
@@ -912,8 +912,19 @@ td {
   -webkit-appearance: none;
      -moz-appearance: none;
           appearance: none;
-  color: red;
+  color: #666;
   flex-shrink: 0;
+  border-radius: 50%;
+  padding: 12px;
+  transition: background-color 0.2s, color 0.2s;
+}
+.modal-close:hover {
+  background-color: #f0f0f0;
+  color: #333;
+}
+.modal-close:focus-visible {
+  outline: 2px solid var(--blue-card);
+  outline-offset: 2px;
 }
 .modal input[type=radio],
 .modal input[type=radio] + label {

--- a/index.html
+++ b/index.html
@@ -210,6 +210,7 @@
                 </a>
             </div>
         </div>
+    </div>
 
     <script src="js/modal.js"></script>
     <script src="js/filters.js"></script>

--- a/index.html
+++ b/index.html
@@ -136,8 +136,8 @@
         <div class="modal-container">
             <div class="modal-header">
                 <p class="modal-title"></p>
-                <button class="modal-close modal-exit button--icon-only" onclick="modalClose(this)">
-                    <span class="icon icon--l icon--inline">
+                <button class="modal-close modal-exit button--icon-only" aria-label="Cerrar" onclick="modalClose(this)">
+                    <span class="icon icon--inline">
                         <svg><use xlink:href="/sources/icons.svg#close"></use></svg>
                     </span>
                 </button>
@@ -196,8 +196,8 @@
         <div class="modal-container">
             <div class="modal-header">
                 <p class="modal-title"></p>
-                <button class="modal-close modal-exit button--icon-only" onclick="modalClose(this)">
-                    <span class="icon icon--l icon--inline">
+                <button class="modal-close modal-exit button--icon-only" aria-label="Cerrar" onclick="modalClose(this)">
+                    <span class="icon icon--inline">
                         <svg><use xlink:href="/sources/icons.svg#close"></use></svg>
                     </span>
                 </button>

--- a/index.html
+++ b/index.html
@@ -134,7 +134,14 @@
     <div class="modal" id="editModal">
         <div class="modal-bg modal-exit" onclick="modalClose(this)"></div>
         <div class="modal-container">
-            <p class="modal-title"></p>
+            <div class="modal-header">
+                <p class="modal-title"></p>
+                <button class="modal-close modal-exit button--icon-only" onclick="modalClose(this)">
+                    <span class="icon icon--l icon--inline">
+                        <svg><use xlink:href="/sources/icons.svg#close"></use></svg>
+                    </span>
+                </button>
+            </div>
             <input type="hidden" name="cardId" id="cardId">
             <img src="#" alt="" class="modal-card">
             <div class="radio-buttons">
@@ -181,18 +188,20 @@
                 <input type="text" name="cardmarketPrice" id="cardmarketPrice" placeholder="P.min">
             </div>
             <button class="modal-ok" onclick="modalOk()">confirmar</button>
-            <button class="modal-close modal-exit button--icon-only" onclick="modalClose(this)">
-                <span class="icon icon--l icon--inline">
-                    <svg><use xlink:href="/sources/icons.svg#close"></use></svg>
-                </span>
-            </button>
         </div>
     </div>
 
     <div class="modal" id="viewModal">
         <div class="modal-bg modal-exit" onclick="modalClose(this)"></div>
         <div class="modal-container">
-            <p class="modal-title"></p>
+            <div class="modal-header">
+                <p class="modal-title"></p>
+                <button class="modal-close modal-exit button--icon-only" onclick="modalClose(this)">
+                    <span class="icon icon--l icon--inline">
+                        <svg><use xlink:href="/sources/icons.svg#close"></use></svg>
+                    </span>
+                </button>
+            </div>
             <img src="#" alt="" class="modal-card">
             <div class="card-info">
                 <span class="card-info__status">Estado: <span id="card-status"></span><span id="card-price"></span></span>
@@ -200,13 +209,7 @@
                     Mínimo: <span id="card-minimum"></span>
                 </a>
             </div>
-            <button class="modal-close modal-exit button--icon-only" onclick="modalClose(this)">
-                <span class="icon icon--l icon--inline">
-                    <svg><use xlink:href="/sources/icons.svg#close"></use></svg>
-                </span>
-            </button>
         </div>
-    </div>
 
     <script src="js/modal.js"></script>
     <script src="js/filters.js"></script>

--- a/sass/_modal.scss
+++ b/sass/_modal.scss
@@ -30,6 +30,7 @@
     background: #fff;
     position: relative;
     padding: 20px;
+    width: 100%;
     max-width: 450px;
   }
 

--- a/sass/_modal.scss
+++ b/sass/_modal.scss
@@ -33,8 +33,14 @@
     max-width: 450px;
   }
 
+  &-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+
   &-title {
-    margin-top: 0;
+    margin: 0;
     font-size: 1.2em;
   }
 
@@ -69,20 +75,10 @@
   }
 
   &-close {
-    position: absolute;
-    right: 10px;
-    top: 10px;
     outline: none;
     appearance: none;
     color: red;
-    // background: none;
-    // border: 1px solid darkred;
-    // font-weight: bold;
-    // cursor: pointer;
-    // font-size: 1em;
-    // background-color: red;
-    // border-radius: 50%;
-    // padding: 1px 5px;
+    flex-shrink: 0;
   }
 
   input[type="radio"],

--- a/sass/_modal.scss
+++ b/sass/_modal.scss
@@ -78,8 +78,21 @@
   &-close {
     outline: none;
     appearance: none;
-    color: red;
+    color: #666;
     flex-shrink: 0;
+    border-radius: 50%;
+    padding: 12px;
+    transition: background-color 0.2s, color 0.2s;
+
+    &:hover {
+      background-color: #f0f0f0;
+      color: #333;
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--blue-card);
+      outline-offset: 2px;
+    }
   }
 
   input[type="radio"],

--- a/sass/_modal.scss
+++ b/sass/_modal.scss
@@ -82,6 +82,7 @@
     flex-shrink: 0;
     border-radius: 50%;
     padding: 12px;
+    margin: -12px -12px -12px 0;
     transition: background-color 0.2s, color 0.2s;
 
     &:hover {


### PR DESCRIPTION
## Summary

Fix modal close button alignment and improve its accessibility. Replace absolute positioning with a flex header layout, add proper WCAG compliance (aria-label, focus-visible, hover state, 44×44px target size).

## Changes

- `index.html` — wrap title + close button in `.modal-header` flex container, add `aria-label="Cerrar"`, reduce icon size
- `sass/_modal.scss` — replace absolute positioning with flex layout, add hover/focus-visible states, ensure 44×44px target
- `css/style.css` — compiled output

Closes #73